### PR TITLE
Travis: fix build and other tweaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: php
 
 php:
@@ -7,8 +8,15 @@ php:
   - 7.0
   - 7.1
   - 7.2
-  
-sudo: false
+  - 7.3
+  - 7.4
+  - "nightly"
+
+jobs:
+  fast_finish: true
+  allow_failures:
+    # Allow failures for unstable builds.
+    - php: "nightly"
 
 cache:
   directories:

--- a/build.xml
+++ b/build.xml
@@ -54,7 +54,7 @@
 
         <exec executable="${phpcs}">
             <arg line='--extensions=php' />
-            <arg line='--standard="${basedir}/vendor/jakub-onderka/php-code-style/ruleset.xml"' />
+            <arg line='--standard="${basedir}/vendor/php-parallel-lint/php-code-style/ruleset.xml"' />
             <arg line='--report-checkstyle="${basedir}/build/logs/checkstyle.xml"' />
             <arg line='--report-full' />
             <arg line='"${basedir}/src"' />


### PR DESCRIPTION
## Travis: fix build and other tweaks

* The build was running on `xenial` which does not have `ant` installed by default, nor has PHP 5.4/5.5 images available.
    Switching to the `trusty` distribution fixes this.
* Support for `sudo: false` has been removed from Travis over a year ago.
* Test against PHP 7.3, 7.4 and PHP `nightly` (= PHP 8), allowing the build against PHP 8 to fail for now.

## Fix build script

The build script was still pointing to an outdated dependency.

Note: even though the PHPCS part of the build is failing, the build isn't being failed. I suspect this has to do with the ` failonerror="true"` attribute missing from the PHPCS command in the `build.xml` file.

