### PR TITLE
Composer: update allowed version for various dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,14 +16,14 @@
     "require": {
         "php": ">=5.4.0",
         "ext-tokenizer": "*",
-        "php-parallel-lint/php-console-color": "~0.2"
+        "php-parallel-lint/php-console-color": "^0.2 || ^0.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8.36",
-        "php-parallel-lint/php-parallel-lint": "~1.0",
-        "php-parallel-lint/php-var-dump-check": "~0.1",
-        "squizlabs/php_codesniffer": "~1.5",
-        "php-parallel-lint/php-code-style": "~1.0"
+        "php-parallel-lint/php-parallel-lint": "^1.0",
+        "php-parallel-lint/php-var-dump-check": "0.*",
+        "squizlabs/php_codesniffer": "^3.5",
+        "php-parallel-lint/php-code-style": "^1.0"
     },
     "replace": {
         "jakub-onderka/php-console-highlighter": "*"


### PR DESCRIPTION
Non-dev:
* PHP Console Color has released version 0.3 in May.
    I've set it to allow both `0.2` as well as `0.3` to prevent conflicts.
    Packages which use this package which may have the Console Color package explicitly set as a requirement.

Dev:
* PHP Parallel Lint has released version 1.2.0 in April.
* PHP Var dump check has released version 0.4 in April.
    I've set this one to be a flexible requirement to prevent having to update it on each new version.
* PHP_CodeSniffer has moved on a lot since version 1.5, so let's use a more recent one.

As it was, installing with PHP Console Color 0.3 was not allowed as Composer treats minors < 1.0 as majors.
So updating to that version requires an update to the `composer.json` requirements.

> For pre-1.0 versions it also acts with safety in mind and treats `^0.3` as `>=0.3.0 <0.4.0`.

Refs:
* https://getcomposer.org/doc/articles/versions.md#caret-version-range-
* https://github.com/php-parallel-lint/PHP-Console-Color/releases/tag/v0.3
* https://github.com/php-parallel-lint/PHP-Parallel-Lint/releases/tag/v1.2.0
* https://github.com/php-parallel-lint/PHP-Var-Dump-Check/releases/tag/v0.4