### PR TITLE
Travis: improve caching between builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ cache:
     - $HOME/.composer/cache
 
 before_script:
-  - composer install --no-interaction --prefer-source
+  - composer install --no-interaction
 
 script:
   - ant


### PR DESCRIPTION
Unless there is a specific reason to use `--prefer-source`, always use `--prefer-dist` for the `composer install` command to allow Travis to optimally use the caching feature.