### PR TITLE
Travis: change from "trusty" to "xenial"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,13 @@
-dist: trusty
+os: linux
+dist: xenial
 language: php
 
+addons:
+  apt:
+    packages:
+      - ant
+
 php:
-  - 5.4
-  - 5.5
   - 5.6
   - 7.0
   - 7.1
@@ -14,6 +18,11 @@ php:
 
 jobs:
   fast_finish: true
+  include:
+    - php: 5.4
+      dist: trusty
+    - php: 5.5
+      dist: trusty
   allow_failures:
     # Allow failures for unstable builds.
     - php: "nightly"


### PR DESCRIPTION
As the "trusty" environment is no longer officially supported by Travis, they decided in their wisdom to silently stop updating the PHP "nightly" image, which makes it next to useless as the last image apparently is from January....

This updates the Travis config to:
* Use the `xenial` distro, which at this time is the default.
* Sets the distro for low PHP versions explicitly to `trusty`.
* Makes the expected OS explicit (linux).
* The `xenial` distro is quite bare, so `ant` is not available by default. Adding this as an `addon` fixes that.