### PR TITLE
Use PHP Console Color to version 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Usage
 -------
 ```php
 <?php
-use JakubOnderka\PhpConsoleColor\ConsoleColor;
+use PHP_Parallel_Lint\PhpConsoleColor\ConsoleColor;
 use JakubOnderka\PhpConsoleHighlighter\Highlighter;
 
 require __DIR__ . '/vendor/autoload.php';

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": ">=5.4.0",
         "ext-tokenizer": "*",
-        "php-parallel-lint/php-console-color": "^0.2 || ^0.3"
+        "php-parallel-lint/php-console-color": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8.36 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0",

--- a/examples/snippet.php
+++ b/examples/snippet.php
@@ -1,5 +1,5 @@
 <?php
-use JakubOnderka\PhpConsoleColor\ConsoleColor;
+use PHP_Parallel_Lint\PhpConsoleColor\ConsoleColor;
 use JakubOnderka\PhpConsoleHighlighter\Highlighter;
 
 require __DIR__ . '/../vendor/autoload.php';

--- a/examples/whole_file.php
+++ b/examples/whole_file.php
@@ -1,5 +1,5 @@
 <?php
-use JakubOnderka\PhpConsoleColor\ConsoleColor;
+use PHP_Parallel_Lint\PhpConsoleColor\ConsoleColor;
 use JakubOnderka\PhpConsoleHighlighter\Highlighter;
 
 require __DIR__ . '/../vendor/autoload.php';

--- a/examples/whole_file_line_numbers.php
+++ b/examples/whole_file_line_numbers.php
@@ -1,5 +1,5 @@
 <?php
-use JakubOnderka\PhpConsoleColor\ConsoleColor;
+use PHP_Parallel_Lint\PhpConsoleColor\ConsoleColor;
 use JakubOnderka\PhpConsoleHighlighter\Highlighter;
 
 require __DIR__ . '/../vendor/autoload.php';

--- a/src/Highlighter.php
+++ b/src/Highlighter.php
@@ -1,7 +1,7 @@
 <?php
 namespace JakubOnderka\PhpConsoleHighlighter;
 
-use JakubOnderka\PhpConsoleColor\ConsoleColor;
+use PHP_Parallel_Lint\PhpConsoleColor\ConsoleColor;
 
 class Highlighter
 {
@@ -31,7 +31,7 @@ class Highlighter
 
     /**
      * @param ConsoleColor $color
-     * @throws \JakubOnderka\PhpConsoleColor\InvalidStyleException
+     * @throws \PHP_Parallel_Lint\PhpConsoleColor\InvalidStyleException
      */
     public function __construct(ConsoleColor $color)
     {
@@ -50,7 +50,7 @@ class Highlighter
      * @param int $linesBefore
      * @param int $linesAfter
      * @return string
-     * @throws \JakubOnderka\PhpConsoleColor\InvalidStyleException
+     * @throws \PHP_Parallel_Lint\PhpConsoleColor\InvalidStyleException
      * @throws \InvalidArgumentException
      */
     public function getCodeSnippet($source, $lineNumber, $linesBefore = 2, $linesAfter = 2)
@@ -70,7 +70,7 @@ class Highlighter
     /**
      * @param string $source
      * @return string
-     * @throws \JakubOnderka\PhpConsoleColor\InvalidStyleException
+     * @throws \PHP_Parallel_Lint\PhpConsoleColor\InvalidStyleException
      * @throws \InvalidArgumentException
      */
     public function getWholeFile($source)
@@ -83,7 +83,7 @@ class Highlighter
     /**
      * @param string $source
      * @return string
-     * @throws \JakubOnderka\PhpConsoleColor\InvalidStyleException
+     * @throws \PHP_Parallel_Lint\PhpConsoleColor\InvalidStyleException
      * @throws \InvalidArgumentException
      */
     public function getWholeFileWithLineNumbers($source)
@@ -215,7 +215,7 @@ class Highlighter
     /**
      * @param array $tokenLines
      * @return array
-     * @throws \JakubOnderka\PhpConsoleColor\InvalidStyleException
+     * @throws \PHP_Parallel_Lint\PhpConsoleColor\InvalidStyleException
      * @throws \InvalidArgumentException
      */
     private function colorLines(array $tokenLines)
@@ -241,7 +241,7 @@ class Highlighter
      * @param array $lines
      * @param null|int $markLine
      * @return string
-     * @throws \JakubOnderka\PhpConsoleColor\InvalidStyleException
+     * @throws \PHP_Parallel_Lint\PhpConsoleColor\InvalidStyleException
      */
     private function lineNumbers(array $lines, $markLine = null)
     {

--- a/tests/HighlighterTest.php
+++ b/tests/HighlighterTest.php
@@ -11,8 +11,8 @@ class HighlighterTest extends TestCase
     protected function getConsoleColorMock()
     {
         $mock = method_exists($this, 'createMock')
-            ? $this->createMock('\JakubOnderka\PhpConsoleColor\ConsoleColor')
-            : $this->getMock('\JakubOnderka\PhpConsoleColor\ConsoleColor');
+            ? $this->createMock('\PHP_Parallel_Lint\PhpConsoleColor\ConsoleColor')
+            : $this->getMock('\PHP_Parallel_Lint\PhpConsoleColor\ConsoleColor');
 
         $mock->expects($this->any())
             ->method('apply')


### PR DESCRIPTION
The `php-parallel-lint/php-console-color` package has tagged a new release.

The most notable change is the namespace update.

This updates the PHP Console Highlighter package to use the new version of PHP Console Color.

Refs:
* https://github.com/php-parallel-lint/PHP-Console-Color/releases/tag/v1.0