### PR TITLE
PHPCS: various improvements

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,4 @@
 .travis.yml export-ignore
 build.xml export-ignore
 phpunit.xml.dist export-ignore
+phpcs.xml.dist export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 /composer.lock
 phpunit.xml
 .phpunit.result.cache
+.phpcs.xml
+phpcs.xml

--- a/build.xml
+++ b/build.xml
@@ -52,12 +52,10 @@
     <target name="phpcs" depends="prepare" description="Check PHP code style">
         <delete file="${basedir}/build/logs/checkstyle.xml" quiet="true" />
 
-        <exec executable="${phpcs}">
-            <arg line='--extensions=php' />
-            <arg line='--standard="${basedir}/vendor/php-parallel-lint/php-code-style/ruleset.xml"' />
+        <exec executable="${phpcs}" failonerror="true">
             <arg line='--report-checkstyle="${basedir}/build/logs/checkstyle.xml"' />
             <arg line='--report-full' />
-            <arg line='"${basedir}/src"' />
+            <arg line='--runtime-set ignore_warnings_on_exit 1' />
         </exec>
     </target>
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<ruleset name="Jakub Onderka Coding Standard">
+    <description>A coding standard for Jakub Onderka's projects.</description>
+
+    <file>./src/</file>
+
+    <!-- Only check PHP files. -->
+    <arg name="extensions" value="php"/>
+
+    <!-- Show progress, show the error codes for each message (source). -->
+    <arg value="ps"/>
+
+    <!-- Strip the filepaths down to the relevant bit. -->
+    <arg name="basepath" value="./"/>
+
+    <rule ref="./vendor/php-parallel-lint/php-code-style/ruleset.xml"/>
+
+	<rule ref="Generic.Metrics.CyclomaticComplexity.MaxExceeded">
+		<type>warning</type>
+	</rule>
+</ruleset>


### PR DESCRIPTION
* PHPCS: add a PHPCS configuration file containing all the common command-line parameters.
    This file will be automatically picked up by PHPCS and can be overruled locally by a `[.]phpcs.xml` file.
    Includes downgrading the cyclomatic complexity error to a warning.
* Ant: remove the configuration CLI arguments which are now contained in the `phpcs.xml.dist` file from the `build.xml` task configuration.
* Ant: add a CLI argument which will ignore CS warnings when determining the exit code, but will still _show_ warnings in the report.
    Using this will also allow for enabling `failonerror` for the build step.
* Git: Add the `phpcs.xml.dist` file to the `.gitattributes` file to be ignored when packaging a release.
* Git: Add the potential local overload files to the `.gitignore` file.