### PR TITLE
Changelog: improve maintainability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Travis: add build against PHP 8.0 [#18](https://github.com/php-parallel-lint/PHP-Console-Highlighter/pull/18) from [@jrfnl](https://github.com/jrfnl).
 - Added EOF (end of file) for some PHP files from [@peter279k](https://github.com/peter279k).
 - To be compatible with future PHPUnit version, using the ^4.8.36 version at least from [@peter279k](https://github.com/peter279k).
-- Changed namespace to PHPunit\Framework\TestCase class namesapce from [@peter279k](https://github.com/peter279k).
+- Changed namespace to PHPunit\Framework\TestCase class namespace from [@peter279k](https://github.com/peter279k).
 - Travis: improve caching between builds [#14](https://github.com/php-parallel-lint/PHP-Console-Highlighter/pull/14) from [@jrfnl](https://github.com/jrfnl).
 - Travis: change from "trusty" to "xenial" [#16](https://github.com/php-parallel-lint/PHP-Console-Highlighter/pull/16) from [@jrfnl](https://github.com/jrfnl).
 - PHPUnit: use a type-safe assertion [#15](https://github.com/php-parallel-lint/PHP-Console-Highlighter/pull/15) from [@jrfnl](https://github.com/jrfnl).
@@ -38,7 +38,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Cleaned readme - new organization from previous package from [@grogy](https://github.com/grogy).
 - Composer: marked package as replacing jakub-onderka/php-console-highlighter from [@grogy](https://github.com/grogy).
-- Composer: updated dependancies to use new php-parallel-lint organisation from [@grogy](https://github.com/grogy).
+- Composer: updated dependencies to use new php-parallel-lint organisation from [@grogy](https://github.com/grogy).
 - Travis: test against PHP 7.4 and nightly from [@jrfnl](https://github.com/jrfnl).
 - Fixed build script from [@jrfnl](https://github.com/jrfnl).
 - Added a .gitattributes file from [@reedy](https://github.com/reedy).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-- Composer: update allowed version for various dependencies from [@jrfnl].
+- Composer: update allowed version for various dependencies [#12] from [@jrfnl].
 - Use PHP Console Color to version 1.0 [#17] from [@jrfnl].
 
 ### Internal
 
 - Travis: add build against PHP 8.0 [#18] from [@jrfnl].
-- Added EOF (end of file) for some PHP files from [@peter279k].
-- To be compatible with future PHPUnit version, using the ^4.8.36 version at least from [@peter279k].
-- Changed namespace to PHPunit\Framework\TestCase class namespace from [@peter279k].
+- Added EOF (end of file) for some PHP files [#10] from [@peter279k].
+- To be compatible with future PHPUnit version, using the ^4.8.36 version at least [#10] from [@peter279k].
+- Changed namespace to PHPunit\Framework\TestCase class namespace [#10] from [@peter279k].
 - Travis: improve caching between builds [#14] from [@jrfnl].
 - Travis: change from "trusty" to "xenial" [#16] from [@jrfnl].
 - PHPUnit: use a type-safe assertion [#15] from [@jrfnl].
@@ -28,6 +28,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - CI: switch to ghactions [#23] from [@jrfnl].
 - GH Actions: set error reporting to E_ALL [#24] from [@jrfnl].
 
+[#10]: https://github.com/php-parallel-lint/PHP-Console-Highlighter/pull/10
+[#12]: https://github.com/php-parallel-lint/PHP-Console-Highlighter/pull/12
 [#14]: https://github.com/php-parallel-lint/PHP-Console-Highlighter/pull/14
 [#15]: https://github.com/php-parallel-lint/PHP-Console-Highlighter/pull/15
 [#16]: https://github.com/php-parallel-lint/PHP-Console-Highlighter/pull/16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,39 +8,56 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-- Composer: update allowed version for various dependencies from [@jrfnl](https://github.com/jrfnl).
-- Use PHP Console Color to version 1.0 [#17](https://github.com/php-parallel-lint/PHP-Console-Highlighter/pull/17) from [@jrfnl](https://github.com/jrfnl).
+- Composer: update allowed version for various dependencies from [@jrfnl].
+- Use PHP Console Color to version 1.0 [#17] from [@jrfnl].
 
 ### Internal
 
-- Travis: add build against PHP 8.0 [#18](https://github.com/php-parallel-lint/PHP-Console-Highlighter/pull/18) from [@jrfnl](https://github.com/jrfnl).
-- Added EOF (end of file) for some PHP files from [@peter279k](https://github.com/peter279k).
-- To be compatible with future PHPUnit version, using the ^4.8.36 version at least from [@peter279k](https://github.com/peter279k).
-- Changed namespace to PHPunit\Framework\TestCase class namespace from [@peter279k](https://github.com/peter279k).
-- Travis: improve caching between builds [#14](https://github.com/php-parallel-lint/PHP-Console-Highlighter/pull/14) from [@jrfnl](https://github.com/jrfnl).
-- Travis: change from "trusty" to "xenial" [#16](https://github.com/php-parallel-lint/PHP-Console-Highlighter/pull/16) from [@jrfnl](https://github.com/jrfnl).
-- PHPUnit: use a type-safe assertion [#15](https://github.com/php-parallel-lint/PHP-Console-Highlighter/pull/15) from [@jrfnl](https://github.com/jrfnl).
-- PHPUnit: make the tests platform independent [#15](https://github.com/php-parallel-lint/PHP-Console-Highlighter/pull/15) from [@jrfnl](https://github.com/jrfnl).
-- PHPUnit: use annotations for fixtures / cross-version compat up to PHPUnit 9.x [#15](https://github.com/php-parallel-lint/PHP-Console-Highlighter/pull/15) from [@jrfnl](https://github.com/jrfnl).
-- PHPUnit: improve configuration [#21](https://github.com/php-parallel-lint/PHP-Console-Highlighter/pull/21) from [@jrfnl](https://github.com/jrfnl).
-- PHP 8.0: handle changed tokenization of namespaced names [#19](https://github.com/php-parallel-lint/PHP-Console-Highlighter/pull/19) from [@jrfnl](https://github.com/jrfnl).
-- PHPCS: various improvements [#20](https://github.com/php-parallel-lint/PHP-Console-Highlighter/pull/20) from [@jrfnl](https://github.com/jrfnl).
-- CI: switch to ghactions [#23](https://github.com/php-parallel-lint/PHP-Console-Highlighter/pull/23) from [@jrfnl](https://github.com/jrfnl).
-- GH Actions: set error reporting to E_ALL [#24](https://github.com/php-parallel-lint/PHP-Console-Highlighter/pull/24) from [@jrfnl](https://github.com/jrfnl).
+- Travis: add build against PHP 8.0 [#18] from [@jrfnl].
+- Added EOF (end of file) for some PHP files from [@peter279k].
+- To be compatible with future PHPUnit version, using the ^4.8.36 version at least from [@peter279k].
+- Changed namespace to PHPunit\Framework\TestCase class namespace from [@peter279k].
+- Travis: improve caching between builds [#14] from [@jrfnl].
+- Travis: change from "trusty" to "xenial" [#16] from [@jrfnl].
+- PHPUnit: use a type-safe assertion [#15] from [@jrfnl].
+- PHPUnit: make the tests platform independent [#15] from [@jrfnl].
+- PHPUnit: use annotations for fixtures / cross-version compat up to PHPUnit 9.x [#15] from [@jrfnl].
+- PHPUnit: improve configuration [#21] from [@jrfnl].
+- PHP 8.0: handle changed tokenization of namespaced names [#19] from [@jrfnl].
+- PHPCS: various improvements [#20] from [@jrfnl].
+- CI: switch to ghactions [#23] from [@jrfnl].
+- GH Actions: set error reporting to E_ALL [#24] from [@jrfnl].
+
+[#14]: https://github.com/php-parallel-lint/PHP-Console-Highlighter/pull/14
+[#15]: https://github.com/php-parallel-lint/PHP-Console-Highlighter/pull/15
+[#16]: https://github.com/php-parallel-lint/PHP-Console-Highlighter/pull/16
+[#17]: https://github.com/php-parallel-lint/PHP-Console-Highlighter/pull/17
+[#18]: https://github.com/php-parallel-lint/PHP-Console-Highlighter/pull/18
+[#19]: https://github.com/php-parallel-lint/PHP-Console-Highlighter/pull/19
+[#20]: https://github.com/php-parallel-lint/PHP-Console-Highlighter/pull/20
+[#21]: https://github.com/php-parallel-lint/PHP-Console-Highlighter/pull/21
+[#23]: https://github.com/php-parallel-lint/PHP-Console-Highlighter/pull/23
+[#24]: https://github.com/php-parallel-lint/PHP-Console-Highlighter/pull/24
+
 
 ## [0.5] - 2020-05-13
 
 ### Added
 
-- Added changelog from [@reedy](https://github.com/reedy).
+- Added changelog from [@reedy].
 
 ### Internal
 
-- Cleaned readme - new organization from previous package from [@grogy](https://github.com/grogy).
-- Composer: marked package as replacing jakub-onderka/php-console-highlighter from [@grogy](https://github.com/grogy).
-- Composer: updated dependencies to use new php-parallel-lint organisation from [@grogy](https://github.com/grogy).
-- Travis: test against PHP 7.4 and nightly from [@jrfnl](https://github.com/jrfnl).
-- Fixed build script from [@jrfnl](https://github.com/jrfnl).
-- Added a .gitattributes file from [@reedy](https://github.com/reedy).
-- Updated installation command from [@cafferata](https://github.com/cafferata).
+- Cleaned readme - new organization from previous package from [@grogy].
+- Composer: marked package as replacing jakub-onderka/php-console-highlighter from [@grogy].
+- Composer: updated dependencies to use new php-parallel-lint organisation from [@grogy].
+- Travis: test against PHP 7.4 and nightly from [@jrfnl].
+- Fixed build script from [@jrfnl].
+- Added a .gitattributes file from [@reedy].
+- Updated installation command from [@cafferata].
 
+[@cafferata]: https://github.com/cafferata
+[@grogy]: https://github.com/grogy
+[@jrfnl]: https://github.com/jrfnl
+[@peter279k]: https://github.com/peter279k
+[@reedy]: https://github.com/reedy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-- Composer: update allowed version for various dependencies [#12] from [@jrfnl].
+- PHP 8.0: handle changed tokenization of namespaced names [#19] from [@jrfnl].
 - Use PHP Console Color to version 1.0 [#17] from [@jrfnl].
 
 ### Internal
@@ -23,8 +23,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - PHPUnit: make the tests platform independent [#15] from [@jrfnl].
 - PHPUnit: use annotations for fixtures / cross-version compat up to PHPUnit 9.x [#15] from [@jrfnl].
 - PHPUnit: improve configuration [#21] from [@jrfnl].
-- PHP 8.0: handle changed tokenization of namespaced names [#19] from [@jrfnl].
 - PHPCS: various improvements [#20] from [@jrfnl].
+- Composer: update allowed version for various dependencies [#12] from [@jrfnl].
 - CI: switch to ghactions [#23] from [@jrfnl].
 - GH Actions: set error reporting to E_ALL [#24] from [@jrfnl].
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added a .gitattributes file from [@reedy].
 - Updated installation command from [@cafferata].
 
+
+[Unreleased]: https://github.com/php-parallel-lint/PHP-Console-Highlighter/compare/v0.5...HEAD
+[0.5]: https://github.com/php-parallel-lint/PHP-Console-Highlighter/compare/v0.4...v0.5
+
 [@cafferata]: https://github.com/cafferata
 [@grogy]: https://github.com/grogy
 [@jrfnl]: https://github.com/jrfnl


### PR DESCRIPTION
### Changelog: fix some typos

### Changelog: use link lists

This helps to:
1. Keep the changelog readable when editing the markdown and
2. Removes the need to duplicate the links to contributors all over the place.

### Changelog: add missing PR links in "unreleased"

### Changelog: add missing tag links

### Changelog: move two entries around

* The PHP 8.0 tokenization change is a functional fix.
* The dependency change from #12 only affects dev dependencies (as Console Color was updated again later in #17).