### PR TITLE
Use PHP-Code-Style 2.0 

### DIFF
--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -38,7 +38,7 @@ jobs:
         run: vendor/bin/phpcs --report-full --report-checkstyle=./checkstyle.xml
 
       - name: Show PHPCS results in PR
-        run: cs2pr ./checkstyle.xml --graceful-warnings
+        run: cs2pr ./checkstyle.xml
 
       - name: Make sure no vardumps remain
         run: composer vardumpcheck

--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,7 @@
         "phpunit/phpunit": "^4.8.36 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
         "php-parallel-lint/php-parallel-lint": "^1.0",
         "php-parallel-lint/php-var-dump-check": "0.*",
-        "squizlabs/php_codesniffer": "^3.5",
-        "php-parallel-lint/php-code-style": "^1.0"
+        "php-parallel-lint/php-code-style": "^2.0"
     },
     "replace": {
         "jakub-onderka/php-console-highlighter": "*"

--- a/examples/snippet.php
+++ b/examples/snippet.php
@@ -1,4 +1,5 @@
 <?php
+
 use PHP_Parallel_Lint\PhpConsoleColor\ConsoleColor;
 use PHP_Parallel_Lint\PhpConsoleHighlighter\Highlighter;
 

--- a/examples/whole_file.php
+++ b/examples/whole_file.php
@@ -1,4 +1,5 @@
 <?php
+
 use PHP_Parallel_Lint\PhpConsoleColor\ConsoleColor;
 use PHP_Parallel_Lint\PhpConsoleHighlighter\Highlighter;
 

--- a/examples/whole_file_line_numbers.php
+++ b/examples/whole_file_line_numbers.php
@@ -1,4 +1,5 @@
 <?php
+
 use PHP_Parallel_Lint\PhpConsoleColor\ConsoleColor;
 use PHP_Parallel_Lint\PhpConsoleHighlighter\Highlighter;
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -40,10 +40,6 @@
 
     <rule ref="PHPParallelLint"/>
 
-    <rule ref="Generic.Metrics.CyclomaticComplexity.MaxExceeded">
-        <type>warning</type>
-    </rule>
-
     <rule ref="Generic.Files.LineLength">
         <exclude-pattern>*/tests/*</exclude-pattern>
     </rule>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,8 +1,20 @@
 <?xml version="1.0"?>
-<ruleset name="Jakub Onderka Coding Standard">
+<ruleset name="PHP-Console-Highlighter">
     <description>A coding standard for Jakub Onderka's projects.</description>
 
-    <file>./src/</file>
+    <!--
+    #############################################################################
+    COMMAND LINE ARGUMENTS
+    https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml
+    #############################################################################
+    -->
+
+    <!-- Scan all files. -->
+    <file>.</file>
+
+    <!-- Exclude dependencies and auto-generated files. -->
+    <exclude-pattern>*/build/*</exclude-pattern>
+    <exclude-pattern>*/vendor/*</exclude-pattern>
 
     <!-- Only check PHP files. -->
     <arg name="extensions" value="php"/>
@@ -13,9 +25,27 @@
     <!-- Strip the filepaths down to the relevant bit. -->
     <arg name="basepath" value="./"/>
 
-    <rule ref="./vendor/php-parallel-lint/php-code-style/ruleset.xml"/>
+    <!-- Check up to 8 files simultaneously. -->
+    <arg name="parallel" value="8"/>
 
-	<rule ref="Generic.Metrics.CyclomaticComplexity.MaxExceeded">
-		<type>warning</type>
-	</rule>
+
+    <!--
+    #############################################################################
+    USE THE PHPParallelLint RULESET
+    #############################################################################
+    -->
+
+    <!-- Set the supported PHP versions for PHPCompatibility (included in PHPParallelLint). -->
+    <config name="testVersion" value="5.4-"/>
+
+    <rule ref="PHPParallelLint"/>
+
+    <rule ref="Generic.Metrics.CyclomaticComplexity.MaxExceeded">
+        <type>warning</type>
+    </rule>
+
+    <rule ref="Generic.Files.LineLength">
+        <exclude-pattern>*/tests/*</exclude-pattern>
+    </rule>
+
 </ruleset>

--- a/src/Highlighter.php
+++ b/src/Highlighter.php
@@ -30,6 +30,50 @@ class Highlighter
         self::LINE_NUMBER => 'dark_gray',
     );
 
+    /** @var array */
+    private $phpTagTokens = array(
+        T_OPEN_TAG           => T_OPEN_TAG,
+        T_OPEN_TAG_WITH_ECHO => T_OPEN_TAG_WITH_ECHO,
+        T_CLOSE_TAG          => T_CLOSE_TAG,
+    );
+
+    /** @var array */
+    private $magicConstantTokens = array(
+        T_DIR      => T_DIR,
+        T_FILE     => T_FILE,
+        T_LINE     => T_LINE,
+        T_CLASS_C  => T_CLASS_C,
+        T_FUNC_C   => T_FUNC_C,
+        T_METHOD_C => T_METHOD_C,
+        T_NS_C     => T_NS_C,
+        T_TRAIT_C  => T_TRAIT_C,
+    );
+
+    /** @var array */
+    private $miscTokens = array(
+        T_STRING   => T_STRING, // Labels.
+        T_VARIABLE => T_VARIABLE,
+        T_DNUMBER  => T_DNUMBER, // Floats.
+        T_LNUMBER  => T_LNUMBER, // Integers.
+    );
+
+    /** @var array */
+    private $commentTokens = array(
+        T_COMMENT     => T_COMMENT,
+        T_DOC_COMMENT => T_DOC_COMMENT,
+    );
+
+    /** @var array */
+    private $textStringTokens = array(
+        T_ENCAPSED_AND_WHITESPACE  => T_ENCAPSED_AND_WHITESPACE,
+        T_CONSTANT_ENCAPSED_STRING => T_CONSTANT_ENCAPSED_STRING,
+    );
+
+    /** @var array */
+    private $htmlTokens = array(
+        T_INLINE_HTML => T_INLINE_HTML,
+    );
+
     /**
      * @param ConsoleColor $color
      * @throws \PHP_Parallel_Lint\PhpConsoleColor\InvalidStyleException
@@ -152,34 +196,19 @@ class Highlighter
      */
     private function getTokenType($arrayToken)
     {
-        switch ($arrayToken[0]) {
-            case T_OPEN_TAG:
-            case T_OPEN_TAG_WITH_ECHO:
-            case T_CLOSE_TAG:
-            case T_STRING:
-            case T_VARIABLE:
-            // Constants
-            case T_DIR:
-            case T_FILE:
-            case T_METHOD_C:
-            case T_DNUMBER:
-            case T_LNUMBER:
-            case T_NS_C:
-            case T_LINE:
-            case T_CLASS_C:
-            case T_FUNC_C:
-            case T_TRAIT_C:
+        switch (true) {
+            case isset($this->phpTagTokens[$arrayToken[0]]):
+            case isset($this->magicConstantTokens[$arrayToken[0]]):
+            case isset($this->miscTokens[$arrayToken[0]]):
                 return self::TOKEN_DEFAULT;
 
-            case T_COMMENT:
-            case T_DOC_COMMENT:
+            case isset($this->commentTokens[$arrayToken[0]]):
                 return self::TOKEN_COMMENT;
 
-            case T_ENCAPSED_AND_WHITESPACE:
-            case T_CONSTANT_ENCAPSED_STRING:
+            case isset($this->textStringTokens[$arrayToken[0]]):
                 return self::TOKEN_STRING;
 
-            case T_INLINE_HTML:
+            case isset($this->htmlTokens[$arrayToken[0]]):
                 return self::TOKEN_HTML;
         }
 
@@ -187,13 +216,11 @@ class Highlighter
 
         // Handle PHP >= 8.0 namespaced name tokens.
         // https://www.php.net/manual/en/migration80.incompatible.php#migration80.incompatible.tokenizer
-        if (defined('T_NAME_QUALIFIED') && $arrayToken[0] === T_NAME_QUALIFIED) {
-            return self::TOKEN_DEFAULT;
-        }
-        if (defined('T_NAME_FULLY_QUALIFIED') && $arrayToken[0] === T_NAME_FULLY_QUALIFIED) {
-            return self::TOKEN_DEFAULT;
-        }
-        if (defined('T_NAME_RELATIVE') && $arrayToken[0] === T_NAME_RELATIVE) {
+        if (
+            (defined('T_NAME_QUALIFIED') && $arrayToken[0] === T_NAME_QUALIFIED)
+            || (defined('T_NAME_FULLY_QUALIFIED') && $arrayToken[0] === T_NAME_FULLY_QUALIFIED)
+            || (defined('T_NAME_RELATIVE') && $arrayToken[0] === T_NAME_RELATIVE)
+        ) {
             return self::TOKEN_DEFAULT;
         }
 

--- a/src/Highlighter.php
+++ b/src/Highlighter.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHP_Parallel_Lint\PhpConsoleHighlighter;
 
 use PHP_Parallel_Lint\PhpConsoleColor\ConsoleColor;
@@ -157,7 +158,6 @@ class Highlighter
             case T_CLOSE_TAG:
             case T_STRING:
             case T_VARIABLE:
-
             // Constants
             case T_DIR:
             case T_FILE:
@@ -183,6 +183,8 @@ class Highlighter
                 return self::TOKEN_HTML;
         }
 
+        // phpcs:disable PHPCompatibility.Constants.NewConstants -- The new token constants are only used when defined.
+
         // Handle PHP >= 8.0 namespaced name tokens.
         // https://www.php.net/manual/en/migration80.incompatible.php#migration80.incompatible.tokenizer
         if (defined('T_NAME_QUALIFIED') && $arrayToken[0] === T_NAME_QUALIFIED) {
@@ -194,6 +196,8 @@ class Highlighter
         if (defined('T_NAME_RELATIVE') && $arrayToken[0] === T_NAME_RELATIVE) {
             return self::TOKEN_DEFAULT;
         }
+
+        // phpcs:enable
 
         return self::TOKEN_KEYWORD;
     }

--- a/tests/HighlighterTest.php
+++ b/tests/HighlighterTest.php
@@ -1,8 +1,8 @@
 <?php
+
 namespace PHP_Parallel_Lint\PhpConsoleHighlighter\Test;
 
 use PHP_Parallel_Lint\PhpConsoleHighlighter\Highlighter;
-
 use PHPUnit\Framework\TestCase;
 
 class HighlighterTest extends TestCase
@@ -267,8 +267,7 @@ EOL
     public function testEmpty()
     {
         $this->compare(
-            ''
-            ,
+            '',
             ''
         );
     }
@@ -276,8 +275,7 @@ EOL
     public function testWhitespace()
     {
         $this->compare(
-            ' '
-            ,
+            ' ',
             '<token_html> </token_html>'
         );
     }


### PR DESCRIPTION
### PHPCS: use PHP-Code-Style 2.0

* Composer: require `php-parallel-lint/php-code-style` at 2.0 or higher.
* Composer: remove the requirement for PHPCS. This will now be inherited from the code style repo.

### Ruleset: various tweaks for PHP-Code-Style 2.0

* Scan all PHP files, not just the file in `src` for improved consistency across the code base, but exclude the `vendor` and the `build` (code coverage) directories.
* Enable parallel scanning for faster results.
* Use the ruleset from PHP-Code-Style by name.
* Set the `testVersion` for use with PHPCompatibility.
* Exclude the `LineLength` sniff for the tests.
* Include minimal documentation in the ruleset.

### CS: various minor fixes

Fix up the issues which will be flagged by PHP-Code-Style 2.0 and explicitly ignore a couple of (non-)issues.

Includes no longer allowing warnings in the GH Actions build.

### Highlighter::getTokenType(): refactor to lower complexity

Rewrite the method to use predefined token lists.

Includes removing the PHPCS ruleset tweak put in place in an earlier commit.

Fixes #11