### PR TITLE
Composer: allow the PHPCS plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,11 @@
     "replace": {
         "jakub-onderka/php-console-highlighter": "*"
     },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
+    },
     "scripts" : {
         "phplint": [
             "@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude .git"


### PR DESCRIPTION
The `dealerdirect/phpcodesniffer-composer-installer` Composer plugin is used to register external PHPCS standards with PHPCS.

As of Composer 2.2.0, Composer plugins need to be explicitly allowed to run. This adds the necessary configuration for that.

Refs:
* https://blog.packagist.com/composer-2-2/#more-secure-plugin-execution