### PR TITLE
Bring back support for PHP 5.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        php: ['5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
+        php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
         experimental: [false]
 
         include:
@@ -39,6 +39,11 @@ jobs:
           ini-values: zend.assertions=1, error_reporting=-1, display_errors=On
           coverage: none
           tools: cs2pr
+
+      # Remove the PHPCS standard as it has a minimum PHP requirements of PHP 5.4 and would block install on PHP 5.3.
+      - name: 'Composer: remove PHPCS'
+        if: ${{ matrix.php < 5.4 }}
+        run: composer remove --dev php-parallel-lint/php-code-style --no-update --no-interaction
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies

--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,9 @@
         "psr-4": {"PHP_Parallel_Lint\\PhpConsoleHighlighter\\Test\\": "tests/"}
     },
     "require": {
-        "php": ">=5.4.0",
+        "php": ">=5.3.2",
         "ext-tokenizer": "*",
-        "php-parallel-lint/php-console-color": "^1.0"
+        "php-parallel-lint/php-console-color": "^1.0.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8.36 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -36,7 +36,7 @@
     -->
 
     <!-- Set the supported PHP versions for PHPCompatibility (included in PHPParallelLint). -->
-    <config name="testVersion" value="5.4-"/>
+    <config name="testVersion" value="5.3-"/>
 
     <rule ref="PHPParallelLint"/>
 

--- a/src/Highlighter.php
+++ b/src/Highlighter.php
@@ -46,7 +46,6 @@ class Highlighter
         T_FUNC_C   => T_FUNC_C,
         T_METHOD_C => T_METHOD_C,
         T_NS_C     => T_NS_C,
-        T_TRAIT_C  => T_TRAIT_C,
     );
 
     /** @var array */
@@ -213,6 +212,12 @@ class Highlighter
         }
 
         // phpcs:disable PHPCompatibility.Constants.NewConstants -- The new token constants are only used when defined.
+
+        // Traits didn't exist in PHP 5.3 yet, so the trait magic constant needs special casing for PHP >= 5.4.
+        // __TRAIT__ will tokenize as T_STRING in PHP 5.3, so, the end result will be the same cross-version.
+        if (defined('T_TRAIT_C') && $arrayToken[0] === T_TRAIT_C) {
+            return self::TOKEN_DEFAULT;
+        }
 
         // Handle PHP >= 8.0 namespaced name tokens.
         // https://www.php.net/manual/en/migration80.incompatible.php#migration80.incompatible.tokenizer


### PR DESCRIPTION
As Parallel Lint supports PHP 5.3 again since [PR 51](https://github.com/php-parallel-lint/PHP-Parallel-Lint/pull/51), it would be helpful for the Highlighter repo to also support PHP 5.3.

Now [PHP-Console-Color 1.0.1](https://github.com/php-parallel-lint/PHP-Console-Color/releases/tag/v1.0.1) has been released, support for PHP 5.3 can be restored for this repo as well.

This restores the PHP 5.3 minimum version along the same lines as before the version drop in 02b6aa6ea32b14fc15285b17babc3f10857bfb96
The PHP 5.3.2 minimum is in-line with the PHP Console Color minimum version for PHP 5.3.

Includes:
* Enabling a build against PHP 5.3 in the GH Actions workflow.
* Adjusting the `testVersion` for the PHPCompatibility checks to `5.3-` (5.3 and higher).