### PR TITLE
Tests: improve existing tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,11 +32,22 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
+      - name: Setup ini config
+        id: set_ini
+        run: |
+          # On PHP 5.3, short_open_tag needs to be turned on for short open echo tags to be recognized
+          # a PHP tags. As this only affects PHP 5.3, this is not something of serious concern.
+          if [ ${{ matrix.php }} == "5.3" ]; then
+            echo '::set-output name=PHP_INI::zend.assertions=1, error_reporting=-1, display_errors=On, short_open_tag=On'
+          else
+            echo '::set-output name=PHP_INI::zend.assertions=1, error_reporting=-1, display_errors=On'
+          fi
+
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          ini-values: zend.assertions=1, error_reporting=-1, display_errors=On
+          ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
           coverage: none
           tools: cs2pr
 

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "php-parallel-lint/php-console-color": "^1.0.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8.36 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
+        "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
         "php-parallel-lint/php-parallel-lint": "^1.0",
         "php-parallel-lint/php-var-dump-check": "0.*",
         "php-parallel-lint/php-code-style": "^2.0"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,9 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
-    backupGlobals="true"
-    bootstrap="./vendor/autoload.php"
-    colors="true"
-    convertDeprecationsToExceptions="true"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.2/phpunit.xsd"
+        backupGlobals="true"
+        beStrictAboutTestsThatDoNotTestAnything="true"
+        bootstrap="./vendor/autoload.php"
+        colors="true"
+        convertDeprecationsToExceptions="true"
+        convertErrorsToExceptions="true"
+        convertNoticesToExceptions="true"
+        convertWarningsToExceptions="true"
+        forceCoversAnnotation="true"
+        stopOnFailure="false"
+        verbose="true"
     >
 
     <testsuites>
@@ -19,9 +28,9 @@
     </filter>
 
     <logging>
-        <log type="junit" target="build/logs/phpunit.xml"/>
         <log type="coverage-clover" target="build/logs/clover.xml"/>
         <log type="coverage-html" target="build/coverage/"/>
+        <log type="coverage-text" target="php://stdout" showOnlySummary="true"/>
     </logging>
 
     <php>

--- a/tests/TokenizeTest.php
+++ b/tests/TokenizeTest.php
@@ -677,6 +677,84 @@ EOL
 <token_keyword>}</token_keyword>
 EOL
             ),
+            'Keywords: while, empty, exit' => array(
+                'original' => <<<'EOL'
+<?php
+while(empty($a)) { exit; }
+EOL
+                ,
+                'expected' => <<<'EOL'
+<token_default><?php</token_default>
+<token_keyword>while(empty(</token_keyword><token_default>$a</token_default><token_keyword>)) { exit; }</token_keyword>
+EOL
+            ),
+            'Keywords: type casts' => array(
+                'original' => <<<'EOL'
+<?php
+$a = (int) (bool) $a . (string) $b;
+EOL
+                ,
+                'expected' => <<<'EOL'
+<token_default><?php</token_default>
+<token_default>$a </token_default><token_keyword>= (int) (bool) </token_keyword><token_default>$a </token_default><token_keyword>. (string) </token_keyword><token_default>$b</token_default><token_keyword>;</token_keyword>
+EOL
+            ),
+            'Keywords: new, clone' => array(
+                'original' => <<<'EOL'
+<?php
+$obj = new stdClass;
+$clone = clone $obj;
+EOL
+                ,
+                'expected' => <<<'EOL'
+<token_default><?php</token_default>
+<token_default>$obj </token_default><token_keyword>= new </token_keyword><token_default>stdClass</token_default><token_keyword>;</token_keyword>
+<token_default>$clone </token_default><token_keyword>= clone </token_keyword><token_default>$obj</token_default><token_keyword>;</token_keyword>
+EOL
+            ),
+            'Operators: arithmetic operators' => array(
+                'original' => <<<'EOL'
+<?php
+echo 1 + 2 - 2 * 10 / 5 ** 1;
+EOL
+                ,
+                'expected' => <<<'EOL'
+<token_default><?php</token_default>
+<token_keyword>echo </token_keyword><token_default>1 </token_default><token_keyword>+ </token_keyword><token_default>2 </token_default><token_keyword>- </token_keyword><token_default>2 </token_default><token_keyword>* </token_keyword><token_default>10 </token_default><token_keyword>/ </token_keyword><token_default>5 </token_default><token_keyword>** </token_keyword><token_default>1</token_default><token_keyword>;</token_keyword>
+EOL
+            ),
+            'Operators: assignment operators' => array(
+                'original' => <<<'EOL'
+<?php
+$a = 10;
+$a *= 10;
+$a ^= 10;
+$a ??= $b;
+EOL
+                ,
+                'expected' => <<<'EOL'
+<token_default><?php</token_default>
+<token_default>$a </token_default><token_keyword>= </token_keyword><token_default>10</token_default><token_keyword>;</token_keyword>
+<token_default>$a </token_default><token_keyword>*= </token_keyword><token_default>10</token_default><token_keyword>;</token_keyword>
+<token_default>$a </token_default><token_keyword>^= </token_keyword><token_default>10</token_default><token_keyword>;</token_keyword>
+<token_default>$a </token_default><token_keyword>??= </token_keyword><token_default>$b</token_default><token_keyword>;</token_keyword>
+EOL
+            ),
+            'Operators: comparison, boolean and logical operators' => array(
+                'original' => <<<'EOL'
+<?php
+echo '' === '' && '' !== '';
+echo true || '' > '';
+echo '' <=> '' and '' or ! '';
+EOL
+                ,
+                'expected' => <<<'EOL'
+<token_default><?php</token_default>
+<token_keyword>echo </token_keyword><token_string>'' </token_string><token_keyword>=== </token_keyword><token_string>'' </token_string><token_keyword>&& </token_keyword><token_string>'' </token_string><token_keyword>!== </token_keyword><token_string>''</token_string><token_keyword>;</token_keyword>
+<token_keyword>echo </token_keyword><token_default>true </token_default><token_keyword>|| </token_keyword><token_string>'' </token_string><token_keyword>> </token_keyword><token_string>''</token_string><token_keyword>;</token_keyword>
+<token_keyword>echo </token_keyword><token_string>'' </token_string><token_keyword><=> </token_keyword><token_string>'' </token_string><token_keyword>and </token_keyword><token_string>'' </token_string><token_keyword>or ! </token_keyword><token_string>''</token_string><token_keyword>;</token_keyword>
+EOL
+            ),
         );
     }
 }

--- a/tests/TokenizeTest.php
+++ b/tests/TokenizeTest.php
@@ -270,6 +270,74 @@ EOL
         );
     }
 
+    /**
+     * Test the tokenizer and token specific highlighting of comment tokens.
+     *
+     * @dataProvider dataComments
+     *
+     * @param string $original The input string.
+     * @param string $expected The expected output string.
+     */
+    public function testComments($original, $expected)
+    {
+        $this->compare($original, $expected);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array
+     */
+    public function dataComments()
+    {
+        return array(
+            'Doc block: single line' => array(
+                'original' => <<<'EOL'
+<?php
+/** Ahoj */
+EOL
+                ,
+                'expected' => <<<'EOL'
+<token_default><?php</token_default>
+<token_comment>/** Ahoj */</token_comment>
+EOL
+            ),
+            'Star comment: single line' => array(
+                'original' => <<<'EOL'
+<?php
+/* Ahoj */
+EOL
+                ,
+                'expected' => <<<'EOL'
+<token_default><?php</token_default>
+<token_comment>/* Ahoj */</token_comment>
+EOL
+            ),
+            'Slash comment' => array(
+                'original' => <<<'EOL'
+<?php
+// Ahoj
+EOL
+                ,
+                'expected' => <<<'EOL'
+<token_default><?php</token_default>
+<token_comment>// Ahoj</token_comment>
+EOL
+            ),
+            'Hash comment' => array(
+                'original' => <<<'EOL'
+<?php
+# Ahoj
+EOL
+                ,
+                'expected' => <<<'EOL'
+<token_default><?php</token_default>
+<token_comment># Ahoj</token_comment>
+EOL
+            ),
+        );
+    }
+
     public function testBasicFunction()
     {
         $this->compare(
@@ -330,69 +398,6 @@ EOL
             <<<'EOL'
 <token_default><?php</token_default>
 <token_default>$a </token_default><token_keyword>instanceof </token_keyword><token_default>stdClass</token_default><token_keyword>;</token_keyword>
-EOL
-        );
-    }
-
-    /*
-     * Comments
-     */
-    public function testComment()
-    {
-        $this->compare(
-            <<<'EOL'
-<?php
-/* Ahoj */
-EOL
-            ,
-            <<<'EOL'
-<token_default><?php</token_default>
-<token_comment>/* Ahoj */</token_comment>
-EOL
-        );
-    }
-
-    public function testDocComment()
-    {
-        $this->compare(
-            <<<'EOL'
-<?php
-/** Ahoj */
-EOL
-            ,
-            <<<'EOL'
-<token_default><?php</token_default>
-<token_comment>/** Ahoj */</token_comment>
-EOL
-        );
-    }
-
-    public function testInlineComment()
-    {
-        $this->compare(
-            <<<'EOL'
-<?php
-// Ahoj
-EOL
-            ,
-            <<<'EOL'
-<token_default><?php</token_default>
-<token_comment>// Ahoj</token_comment>
-EOL
-        );
-    }
-
-    public function testHashComment()
-    {
-        $this->compare(
-            <<<'EOL'
-<?php
-# Ahoj
-EOL
-            ,
-            <<<'EOL'
-<token_default><?php</token_default>
-<token_comment># Ahoj</token_comment>
 EOL
         );
     }

--- a/tests/TokenizeTest.php
+++ b/tests/TokenizeTest.php
@@ -100,6 +100,48 @@ class TokenizeTest extends TestCase
         );
     }
 
+    /**
+     * Test the tokenizer and token specific highlighting of PHP tag tokens.
+     *
+     * @dataProvider dataPhpTags
+     *
+     * @param string $original The input string.
+     * @param string $expected The expected output string.
+     */
+    public function testPhpTags($original, $expected)
+    {
+        $this->compare($original, $expected);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array
+     */
+    public function dataPhpTags()
+    {
+        return array(
+            '"Long" open tag with close tag' => array(
+                'original' => <<<'EOL'
+<?php echo PHP_EOL; ?>
+EOL
+                ,
+                'expected' => <<<'EOL'
+<token_default><?php </token_default><token_keyword>echo </token_keyword><token_default>PHP_EOL</token_default><token_keyword>; </token_keyword><token_default>?></token_default>
+EOL
+            ),
+            'Short open tag with close tag' => array(
+                'original' => <<<'EOL'
+text <?= /* comment */ ?> more text
+EOL
+                ,
+                'expected' => <<<'EOL'
+<token_html>text </token_html><token_default><?= </token_default><token_comment>/* comment */ </token_comment><token_default>?></token_default><token_html> more text</token_html>
+EOL
+            ),
+        );
+    }
+
     public function testVariable()
     {
         $this->compare(

--- a/tests/TokenizeTest.php
+++ b/tests/TokenizeTest.php
@@ -385,6 +385,52 @@ EOL
         );
     }
 
+    /**
+     * Test the tokenizer and token specific highlighting of text string tokens.
+     *
+     * @dataProvider dataTextStrings
+     *
+     * @param string $original The input string.
+     * @param string $expected The expected output string.
+     */
+    public function testTextStrings($original, $expected)
+    {
+        $this->compare($original, $expected);
+    }
+
+    /**
+     * Data provider for testing text string tokens.
+     *
+     * @return array
+     */
+    public function dataTextStrings()
+    {
+        return array(
+            'Single quoted text string' => array(
+                'original' => <<<'EOL'
+<?php
+echo 'Ahoj světe';
+EOL
+                ,
+                'expected' => <<<'EOL'
+<token_default><?php</token_default>
+<token_keyword>echo </token_keyword><token_string>'Ahoj světe'</token_string><token_keyword>;</token_keyword>
+EOL
+            ),
+            'Double quoted text string' => array(
+                'original' => <<<'EOL'
+<?php
+echo "Ahoj světe";
+EOL
+                ,
+                'expected' => <<<'EOL'
+<token_default><?php</token_default>
+<token_keyword>echo </token_keyword><token_string>"Ahoj světe"</token_string><token_keyword>;</token_keyword>
+EOL
+            ),
+        );
+    }
+
     public function testBasicFunction()
     {
         $this->compare(
@@ -400,36 +446,6 @@ EOL
 <token_keyword>function </token_keyword><token_default>plus</token_default><token_keyword>(</token_keyword><token_default>$a</token_default><token_keyword>, </token_keyword><token_default>$b</token_default><token_keyword>) {</token_keyword>
 <token_keyword>    return </token_keyword><token_default>$a </token_default><token_keyword>+ </token_keyword><token_default>$b</token_default><token_keyword>;</token_keyword>
 <token_keyword>}</token_keyword>
-EOL
-        );
-    }
-
-    public function testStringNormal()
-    {
-        $this->compare(
-            <<<'EOL'
-<?php
-echo 'Ahoj světe';
-EOL
-            ,
-            <<<'EOL'
-<token_default><?php</token_default>
-<token_keyword>echo </token_keyword><token_string>'Ahoj světe'</token_string><token_keyword>;</token_keyword>
-EOL
-        );
-    }
-
-    public function testStringDouble()
-    {
-        $this->compare(
-            <<<'EOL'
-<?php
-echo "Ahoj světe";
-EOL
-            ,
-            <<<'EOL'
-<token_default><?php</token_default>
-<token_keyword>echo </token_keyword><token_string>"Ahoj světe"</token_string><token_keyword>;</token_keyword>
 EOL
         );
     }

--- a/tests/TokenizeTest.php
+++ b/tests/TokenizeTest.php
@@ -60,14 +60,14 @@ class TokenizeTest extends TestCase
     public function testVariable()
     {
         $this->compare(
-            <<<EOL
+            <<<'EOL'
 <?php
-echo \$a;
+echo $a;
 EOL
             ,
-            <<<EOL
+            <<<'EOL'
 <token_default><?php</token_default>
-<token_keyword>echo </token_keyword><token_default>\$a</token_default><token_keyword>;</token_keyword>
+<token_keyword>echo </token_keyword><token_default>$a</token_default><token_keyword>;</token_keyword>
 EOL
         );
     }
@@ -75,12 +75,12 @@ EOL
     public function testInteger()
     {
         $this->compare(
-            <<<EOL
+            <<<'EOL'
 <?php
 echo 43;
 EOL
             ,
-            <<<EOL
+            <<<'EOL'
 <token_default><?php</token_default>
 <token_keyword>echo </token_keyword><token_default>43</token_default><token_keyword>;</token_keyword>
 EOL
@@ -90,12 +90,12 @@ EOL
     public function testFloat()
     {
         $this->compare(
-            <<<EOL
+            <<<'EOL'
 <?php
 echo 43.3;
 EOL
             ,
-            <<<EOL
+            <<<'EOL'
 <token_default><?php</token_default>
 <token_keyword>echo </token_keyword><token_default>43.3</token_default><token_keyword>;</token_keyword>
 EOL
@@ -105,12 +105,12 @@ EOL
     public function testHex()
     {
         $this->compare(
-            <<<EOL
+            <<<'EOL'
 <?php
 echo 0x43;
 EOL
             ,
-            <<<EOL
+            <<<'EOL'
 <token_default><?php</token_default>
 <token_keyword>echo </token_keyword><token_default>0x43</token_default><token_keyword>;</token_keyword>
 EOL
@@ -120,17 +120,17 @@ EOL
     public function testBasicFunction()
     {
         $this->compare(
-            <<<EOL
+            <<<'EOL'
 <?php
-function plus(\$a, \$b) {
-    return \$a + \$b;
+function plus($a, $b) {
+    return $a + $b;
 }
 EOL
             ,
-            <<<EOL
+            <<<'EOL'
 <token_default><?php</token_default>
-<token_keyword>function </token_keyword><token_default>plus</token_default><token_keyword>(</token_keyword><token_default>\$a</token_default><token_keyword>, </token_keyword><token_default>\$b</token_default><token_keyword>) {</token_keyword>
-<token_keyword>    return </token_keyword><token_default>\$a </token_default><token_keyword>+ </token_keyword><token_default>\$b</token_default><token_keyword>;</token_keyword>
+<token_keyword>function </token_keyword><token_default>plus</token_default><token_keyword>(</token_keyword><token_default>$a</token_default><token_keyword>, </token_keyword><token_default>$b</token_default><token_keyword>) {</token_keyword>
+<token_keyword>    return </token_keyword><token_default>$a </token_default><token_keyword>+ </token_keyword><token_default>$b</token_default><token_keyword>;</token_keyword>
 <token_keyword>}</token_keyword>
 EOL
         );
@@ -139,12 +139,12 @@ EOL
     public function testStringNormal()
     {
         $this->compare(
-            <<<EOL
+            <<<'EOL'
 <?php
 echo 'Ahoj světe';
 EOL
             ,
-            <<<EOL
+            <<<'EOL'
 <token_default><?php</token_default>
 <token_keyword>echo </token_keyword><token_string>'Ahoj světe'</token_string><token_keyword>;</token_keyword>
 EOL
@@ -154,12 +154,12 @@ EOL
     public function testStringDouble()
     {
         $this->compare(
-            <<<EOL
+            <<<'EOL'
 <?php
 echo "Ahoj světe";
 EOL
             ,
-            <<<EOL
+            <<<'EOL'
 <token_default><?php</token_default>
 <token_keyword>echo </token_keyword><token_string>"Ahoj světe"</token_string><token_keyword>;</token_keyword>
 EOL
@@ -169,14 +169,14 @@ EOL
     public function testInstanceof()
     {
         $this->compare(
-            <<<EOL
+            <<<'EOL'
 <?php
-\$a instanceof stdClass;
+$a instanceof stdClass;
 EOL
             ,
-            <<<EOL
+            <<<'EOL'
 <token_default><?php</token_default>
-<token_default>\$a </token_default><token_keyword>instanceof </token_keyword><token_default>stdClass</token_default><token_keyword>;</token_keyword>
+<token_default>$a </token_default><token_keyword>instanceof </token_keyword><token_default>stdClass</token_default><token_keyword>;</token_keyword>
 EOL
         );
     }
@@ -218,12 +218,12 @@ EOL
     public function testComment()
     {
         $this->compare(
-            <<<EOL
+            <<<'EOL'
 <?php
 /* Ahoj */
 EOL
             ,
-            <<<EOL
+            <<<'EOL'
 <token_default><?php</token_default>
 <token_comment>/* Ahoj */</token_comment>
 EOL
@@ -233,12 +233,12 @@ EOL
     public function testDocComment()
     {
         $this->compare(
-            <<<EOL
+            <<<'EOL'
 <?php
 /** Ahoj */
 EOL
             ,
-            <<<EOL
+            <<<'EOL'
 <token_default><?php</token_default>
 <token_comment>/** Ahoj */</token_comment>
 EOL
@@ -248,12 +248,12 @@ EOL
     public function testInlineComment()
     {
         $this->compare(
-            <<<EOL
+            <<<'EOL'
 <?php
 // Ahoj
 EOL
             ,
-            <<<EOL
+            <<<'EOL'
 <token_default><?php</token_default>
 <token_comment>// Ahoj</token_comment>
 EOL
@@ -263,12 +263,12 @@ EOL
     public function testHashComment()
     {
         $this->compare(
-            <<<EOL
+            <<<'EOL'
 <?php
 # Ahoj
 EOL
             ,
-            <<<EOL
+            <<<'EOL'
 <token_default><?php</token_default>
 <token_comment># Ahoj</token_comment>
 EOL

--- a/tests/TokenizeTest.php
+++ b/tests/TokenizeTest.php
@@ -428,6 +428,81 @@ EOL
 <token_keyword>echo </token_keyword><token_string>"Ahoj světe"</token_string><token_keyword>;</token_keyword>
 EOL
             ),
+            'Double quoted text string with interpolation [1]' => array(
+                'original' => <<<'EOL'
+<?php
+echo "Ahoj $text and more text";
+EOL
+                ,
+                'expected' => <<<'EOL'
+<token_default><?php</token_default>
+<token_keyword>echo </token_keyword><token_string>"Ahoj </token_string><token_default>$text</token_default><token_string> and more text"</token_string><token_keyword>;</token_keyword>
+EOL
+            ),
+            'Double quoted text string with interpolation [2]' => array(
+                'original' => <<<'EOL'
+<?php
+echo "$text and more text";
+EOL
+                ,
+                'expected' => <<<'EOL'
+<token_default><?php</token_default>
+<token_keyword>echo </token_keyword><token_string>"</token_string><token_default>$text</token_default><token_string> and more text"</token_string><token_keyword>;</token_keyword>
+EOL
+            ),
+            'Double quoted text string with interpolation [3]' => array(
+                'original' => <<<'EOL'
+<?php
+echo "Ahoj {$obj->prop} and more text";
+EOL
+                ,
+                'expected' => <<<'EOL'
+<token_default><?php</token_default>
+<token_keyword>echo </token_keyword><token_string>"Ahoj </token_string><token_keyword>{</token_keyword><token_default>$obj</token_default><token_keyword>-></token_keyword><token_default>prop</token_default><token_keyword>}</token_keyword><token_string> and more text"</token_string><token_keyword>;</token_keyword>
+EOL
+            ),
+            'Nowdoc' => array(
+                'original' => '<?php
+echo <<<\'TXT\'
+Text
+TXT;
+',
+                'expected' => <<<'EOL'
+<token_default><?php</token_default>
+<token_keyword>echo <<<'TXT'</token_keyword>
+<token_string>Text</token_string>
+<token_keyword>TXT;</token_keyword>
+
+EOL
+            ),
+            'Heredoc' => array(
+                'original' => '<?php
+echo <<<TXT
+Text
+TXT;
+',
+                'expected' => <<<'EOL'
+<token_default><?php</token_default>
+<token_keyword>echo <<<TXT</token_keyword>
+<token_string>Text</token_string>
+<token_keyword>TXT;</token_keyword>
+
+EOL
+            ),
+            'Heredoc with interpolation' => array(
+                'original' => '<?php
+echo <<<TXT
+Text $text
+TXT;
+',
+                'expected' => <<<'EOL'
+<token_default><?php</token_default>
+<token_keyword>echo <<<TXT</token_keyword>
+<token_string>Text </token_string><token_default>$text</token_default>
+<token_keyword>TXT;</token_keyword>
+
+EOL
+            ),
         );
     }
 

--- a/tests/TokenizeTest.php
+++ b/tests/TokenizeTest.php
@@ -302,6 +302,25 @@ EOL
 <token_comment>/** Ahoj */</token_comment>
 EOL
             ),
+            'Doc block: multi line' => array(
+                'original' => <<<'EOL'
+<?php
+/**
+ * Ahoj
+ *
+ * @param type $name Description
+ */
+EOL
+                ,
+                'expected' => <<<'EOL'
+<token_default><?php</token_default>
+<token_comment>/**</token_comment>
+<token_comment> * Ahoj</token_comment>
+<token_comment> *</token_comment>
+<token_comment> * @param type $name Description</token_comment>
+<token_comment> */</token_comment>
+EOL
+            ),
             'Star comment: single line' => array(
                 'original' => <<<'EOL'
 <?php
@@ -313,6 +332,21 @@ EOL
 <token_comment>/* Ahoj */</token_comment>
 EOL
             ),
+            'Star comment: multi line' => array(
+                'original' => <<<'EOL'
+<?php
+/*
+    Ahoj
+ */
+EOL
+                ,
+                'expected' => <<<'EOL'
+<token_default><?php</token_default>
+<token_comment>/*</token_comment>
+<token_comment>    Ahoj</token_comment>
+<token_comment> */</token_comment>
+EOL
+            ),
             'Slash comment' => array(
                 'original' => <<<'EOL'
 <?php
@@ -322,6 +356,19 @@ EOL
                 'expected' => <<<'EOL'
 <token_default><?php</token_default>
 <token_comment>// Ahoj</token_comment>
+EOL
+            ),
+            'Slash comment, multiple' => array(
+                'original' => <<<'EOL'
+<?php
+// Ahoj
+// Ahoj again
+EOL
+                ,
+                'expected' => <<<'EOL'
+<token_default><?php</token_default>
+<token_comment>// Ahoj</token_comment>
+<token_comment>// Ahoj again</token_comment>
 EOL
             ),
             'Hash comment' => array(

--- a/tests/TokenizeTest.php
+++ b/tests/TokenizeTest.php
@@ -142,6 +142,55 @@ EOL
         );
     }
 
+    /**
+     * Test the tokenizer and token specific highlighting of the magic constants.
+     *
+     * @dataProvider dataMagicConstants
+     *
+     * @param string $original The input string.
+     * @param string $expected The expected output string.
+     */
+    public function testMagicConstants($original, $expected)
+    {
+        $this->compare($original, $expected);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array
+     */
+    public function dataMagicConstants()
+    {
+        $magicConstants = array(
+            '__FILE__',
+            '__LINE__',
+            '__CLASS__',
+            '__FUNCTION__',
+            '__METHOD__',
+            '__TRAIT__',
+            '__DIR__',
+            '__NAMESPACE__'
+        );
+
+        $data = array();
+        foreach ($magicConstants as $constant) {
+            $data['Magic constant: ' . $constant] = array(
+                'original' => <<<EOL
+<?php
+$constant;
+EOL
+                ,
+                'expected' => <<<EOL
+<token_default><?php</token_default>
+<token_default>$constant</token_default><token_keyword>;</token_keyword>
+EOL
+            );
+        }
+
+        return $data;
+    }
+
     public function testVariable()
     {
         $this->compare(
@@ -264,37 +313,6 @@ EOL
 <token_default>$a </token_default><token_keyword>instanceof </token_keyword><token_default>stdClass</token_default><token_keyword>;</token_keyword>
 EOL
         );
-    }
-
-    /*
-     * Constants
-     */
-    public function testConstant()
-    {
-        $constants = array(
-            '__FILE__',
-            '__LINE__',
-            '__CLASS__',
-            '__FUNCTION__',
-            '__METHOD__',
-            '__TRAIT__',
-            '__DIR__',
-            '__NAMESPACE__'
-        );
-
-        foreach ($constants as $constant) {
-            $this->compare(
-                <<<EOL
-<?php
-$constant;
-EOL
-                ,
-                <<<EOL
-<token_default><?php</token_default>
-<token_default>$constant</token_default><token_keyword>;</token_keyword>
-EOL
-            );
-        }
     }
 
     /*

--- a/tests/TokenizeTest.php
+++ b/tests/TokenizeTest.php
@@ -5,11 +5,30 @@ namespace PHP_Parallel_Lint\PhpConsoleHighlighter\Test;
 use PHP_Parallel_Lint\PhpConsoleHighlighter\Highlighter;
 use PHPUnit\Framework\TestCase;
 
-class HighlighterTest extends TestCase
+/**
+ * Test support for all token types.
+ *
+ * @covers PHP_Parallel_Lint\PhpConsoleHighlighter\Highlighter::tokenize
+ * @covers PHP_Parallel_Lint\PhpConsoleHighlighter\Highlighter::getTokenType
+ */
+class TokenizeTest extends TestCase
 {
     /** @var Highlighter */
     private $uut;
 
+    /**
+     * @before
+     */
+    protected function setUpHighlighter()
+    {
+        $this->uut = new Highlighter($this->getConsoleColorMock());
+    }
+
+    /**
+     * Helper method mocking the Console Color Class.
+     *
+     * @return \PHP_Parallel_Lint\PhpConsoleColor\ConsoleColor
+     */
     protected function getConsoleColorMock()
     {
         $mock = method_exists($this, 'createMock')
@@ -27,14 +46,6 @@ class HighlighterTest extends TestCase
             ->will($this->returnValue(true));
 
         return $mock;
-    }
-
-    /**
-     * @before
-     */
-    protected function setUpHighlighter()
-    {
-        $this->uut = new Highlighter($this->getConsoleColorMock());
     }
 
     protected function compare($original, $expected)

--- a/tests/TokenizeTest.php
+++ b/tests/TokenizeTest.php
@@ -48,6 +48,17 @@ class TokenizeTest extends TestCase
         return $mock;
     }
 
+    /**
+     * Helper method executing the actual tests.
+     *
+     * {@internal This is a work-around to allow for supporting PHPUnit 4.x.
+     * In PHPUnit 5 and higher, a test method can have multiple data provider tags and
+     * will execute the test cases for each. Unfortunately, that wasn't supported in PHPUnit 4.x.
+     * This effectively means that each data provider needs its own test method for now.}
+     *
+     * @param string $original The input string.
+     * @param string $expected The expected output string.
+     */
     protected function compare($original, $expected)
     {
         $output = $this->uut->getWholeFile($original);
@@ -55,6 +66,38 @@ class TokenizeTest extends TestCase
         $output = str_replace(array("\r\n", "\r"), "\n", $output);
 
         $this->assertSame($expected, $output);
+    }
+
+    /**
+     * Test the tokenizer and token specific highlighting of "empty" inputs.
+     *
+     * @dataProvider dataEmptyFiles
+     *
+     * @param string $original The input string.
+     * @param string $expected The expected output string.
+     */
+    public function testEmptyFiles($original, $expected)
+    {
+        $this->compare($original, $expected);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array
+     */
+    public function dataEmptyFiles()
+    {
+        return array(
+            'Empty file' => array(
+                'original' => '',
+                'expected' => '',
+            ),
+            'File only containing whitespace' => array(
+                'original' => '  ',
+                'expected' => '<token_html>  </token_html>',
+            ),
+        );
     }
 
     public function testVariable()
@@ -272,22 +315,6 @@ EOL
 <token_default><?php</token_default>
 <token_comment># Ahoj</token_comment>
 EOL
-        );
-    }
-
-    public function testEmpty()
-    {
-        $this->compare(
-            '',
-            ''
-        );
-    }
-
-    public function testWhitespace()
-    {
-        $this->compare(
-            ' ',
-            '<token_html> </token_html>'
         );
     }
 

--- a/tests/TokenizeTest.php
+++ b/tests/TokenizeTest.php
@@ -506,6 +506,39 @@ EOL
         );
     }
 
+    /**
+     * Test the tokenizer and token specific highlighting of inline HTML tokens.
+     *
+     * @dataProvider dataInlineHtml
+     *
+     * @param string $original The input string.
+     * @param string $expected The expected output string.
+     */
+    public function testInlineHtml($original, $expected)
+    {
+        $this->compare($original, $expected);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array
+     */
+    public function dataInlineHtml()
+    {
+        return array(
+            'Inline HTML' => array(
+                'original' => <<<'EOL'
+<div><?= $text ?></div>
+EOL
+                ,
+                'expected' => <<<'EOL'
+<token_html><div></token_html><token_default><?= $text ?></token_default><token_html></div></token_html>
+EOL
+            ),
+        );
+    }
+
     public function testBasicFunction()
     {
         $this->compare(

--- a/tests/TokenizeTest.php
+++ b/tests/TokenizeTest.php
@@ -212,6 +212,17 @@ EOL
     public function dataMiscTokens()
     {
         return array(
+            'Constant (T_STRING)' => array(
+                'original' => <<<'EOL'
+<?php
+echo PHP_EOL;
+EOL
+                ,
+                'expected' => <<<'EOL'
+<token_default><?php</token_default>
+<token_keyword>echo </token_keyword><token_default>PHP_EOL</token_default><token_keyword>;</token_keyword>
+EOL
+            ),
             'Variable' => array(
                 'original' => <<<'EOL'
 <?php

--- a/tests/TokenizeTest.php
+++ b/tests/TokenizeTest.php
@@ -191,63 +191,71 @@ EOL
         return $data;
     }
 
-    public function testVariable()
+    /**
+     * Test the tokenizer and token specific highlighting of the "miscellaneous" tokens.
+     *
+     * @dataProvider dataMiscTokens
+     *
+     * @param string $original The input string.
+     * @param string $expected The expected output string.
+     */
+    public function testMiscTokens($original, $expected)
     {
-        $this->compare(
-            <<<'EOL'
+        $this->compare($original, $expected);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array
+     */
+    public function dataMiscTokens()
+    {
+        return array(
+            'Variable' => array(
+                'original' => <<<'EOL'
 <?php
 echo $a;
 EOL
-            ,
-            <<<'EOL'
+                ,
+                'expected' => <<<'EOL'
 <token_default><?php</token_default>
 <token_keyword>echo </token_keyword><token_default>$a</token_default><token_keyword>;</token_keyword>
 EOL
-        );
-    }
-
-    public function testInteger()
-    {
-        $this->compare(
-            <<<'EOL'
+            ),
+            'Integer: decimal' => array(
+                'original' => <<<'EOL'
 <?php
 echo 43;
 EOL
-            ,
-            <<<'EOL'
+                ,
+                'expected' => <<<'EOL'
 <token_default><?php</token_default>
 <token_keyword>echo </token_keyword><token_default>43</token_default><token_keyword>;</token_keyword>
 EOL
-        );
-    }
-
-    public function testFloat()
-    {
-        $this->compare(
-            <<<'EOL'
-<?php
-echo 43.3;
-EOL
-            ,
-            <<<'EOL'
-<token_default><?php</token_default>
-<token_keyword>echo </token_keyword><token_default>43.3</token_default><token_keyword>;</token_keyword>
-EOL
-        );
-    }
-
-    public function testHex()
-    {
-        $this->compare(
-            <<<'EOL'
+            ),
+            'Integer: hexadecimal' => array(
+                'original' => <<<'EOL'
 <?php
 echo 0x43;
 EOL
-            ,
-            <<<'EOL'
+                ,
+                'expected' => <<<'EOL'
 <token_default><?php</token_default>
 <token_keyword>echo </token_keyword><token_default>0x43</token_default><token_keyword>;</token_keyword>
 EOL
+            ),
+            'Float' => array(
+                'original' => <<<'EOL'
+<?php
+echo 43.3;
+EOL
+                ,
+                'expected' => <<<'EOL'
+<token_default><?php</token_default>
+<token_keyword>echo </token_keyword><token_default>43.3</token_default><token_keyword>;</token_keyword>
+EOL
+            ),
         );
     }
 

--- a/tests/TokenizeTest.php
+++ b/tests/TokenizeTest.php
@@ -539,6 +539,97 @@ EOL
         );
     }
 
+    /**
+     * Test the tokenizer and token specific highlighting of name tokens.
+     *
+     * @dataProvider dataNameTokens
+     *
+     * @param string $original The input string.
+     * @param string $expected The expected output string.
+     */
+    public function testNameTokens($original, $expected)
+    {
+        $this->compare($original, $expected);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array
+     */
+    public function dataNameTokens()
+    {
+        $data = array(
+            'Unqualified function call' => array(
+                'original' => <<<'EOL'
+<?php
+echo functionName();
+EOL
+                ,
+                'expected' => <<<'EOL'
+<token_default><?php</token_default>
+<token_keyword>echo </token_keyword><token_default>functionName</token_default><token_keyword>();</token_keyword>
+EOL
+            ),
+        );
+
+        $data['Fully qualified function call'] = array(
+            'original' => <<<'EOL'
+<?php
+echo \My\Package\functionName();
+EOL
+        );
+        if (PHP_VERSION_ID < 80000) {
+            $data['Fully qualified function call']['expected'] = <<<'EOL'
+<token_default><?php</token_default>
+<token_keyword>echo \</token_keyword><token_default>My</token_default><token_keyword>\</token_keyword><token_default>Package</token_default><token_keyword>\</token_keyword><token_default>functionName</token_default><token_keyword>();</token_keyword>
+EOL;
+        } else {
+            $data['Fully qualified function call']['expected'] = <<<'EOL'
+<token_default><?php</token_default>
+<token_keyword>echo </token_keyword><token_default>\My\Package\functionName</token_default><token_keyword>();</token_keyword>
+EOL;
+        }
+
+        $data['Namespace relative function call'] = array(
+            'original' => <<<'EOL'
+<?php
+echo namespace\functionName();
+EOL
+        );
+        if (PHP_VERSION_ID < 80000) {
+            $data['Namespace relative function call']['expected'] = <<<'EOL'
+<token_default><?php</token_default>
+<token_keyword>echo namespace\</token_keyword><token_default>functionName</token_default><token_keyword>();</token_keyword>
+EOL;
+        } else {
+            $data['Namespace relative function call']['expected'] = <<<'EOL'
+<token_default><?php</token_default>
+<token_keyword>echo </token_keyword><token_default>namespace\functionName</token_default><token_keyword>();</token_keyword>
+EOL;
+        }
+
+        $data['Partially qualified function call'] = array(
+            'original' => <<<'EOL'
+<?php
+echo Package\functionName();
+EOL
+        );
+        if (PHP_VERSION_ID < 80000) {
+            $data['Partially qualified function call']['expected'] = <<<'EOL'
+<token_default><?php</token_default>
+<token_keyword>echo </token_keyword><token_default>Package</token_default><token_keyword>\</token_keyword><token_default>functionName</token_default><token_keyword>();</token_keyword>
+EOL;
+        } else {
+            $data['Partially qualified function call']['expected'] = <<<'EOL'
+<token_default><?php</token_default>
+<token_keyword>echo </token_keyword><token_default>Package\functionName</token_default><token_keyword>();</token_keyword>
+EOL;
+        }
+
+        return $data;
+    }
+
     public function testBasicFunction()
     {
         $this->compare(
@@ -571,86 +662,5 @@ EOL
 <token_default>$a </token_default><token_keyword>instanceof </token_keyword><token_default>stdClass</token_default><token_keyword>;</token_keyword>
 EOL
         );
-    }
-
-    public function testFunctionCall()
-    {
-        $this->compare(
-            <<<'EOL'
-<?php
-echo functionName();
-EOL
-            ,
-            <<<'EOL'
-<token_default><?php</token_default>
-<token_keyword>echo </token_keyword><token_default>functionName</token_default><token_keyword>();</token_keyword>
-EOL
-        );
-    }
-
-    public function testFQNFunctionCall()
-    {
-        $original = <<<'EOL'
-<?php
-echo \My\Package\functionName();
-EOL;
-
-        if (PHP_VERSION_ID < 80000) {
-            $expected = <<<'EOL'
-<token_default><?php</token_default>
-<token_keyword>echo \</token_keyword><token_default>My</token_default><token_keyword>\</token_keyword><token_default>Package</token_default><token_keyword>\</token_keyword><token_default>functionName</token_default><token_keyword>();</token_keyword>
-EOL;
-        } else {
-            $expected = <<<'EOL'
-<token_default><?php</token_default>
-<token_keyword>echo </token_keyword><token_default>\My\Package\functionName</token_default><token_keyword>();</token_keyword>
-EOL;
-        }
-
-        $this->compare($original, $expected);
-    }
-
-    public function testNamespaceRelativeFunctionCall()
-    {
-        $original = <<<'EOL'
-<?php
-echo namespace\functionName();
-EOL;
-
-        if (PHP_VERSION_ID < 80000) {
-            $expected = <<<'EOL'
-<token_default><?php</token_default>
-<token_keyword>echo namespace\</token_keyword><token_default>functionName</token_default><token_keyword>();</token_keyword>
-EOL;
-        } else {
-            $expected = <<<'EOL'
-<token_default><?php</token_default>
-<token_keyword>echo </token_keyword><token_default>namespace\functionName</token_default><token_keyword>();</token_keyword>
-EOL;
-        }
-
-        $this->compare($original, $expected);
-    }
-
-    public function testQualifiedFunctionCall()
-    {
-        $original = <<<'EOL'
-<?php
-echo Package\functionName();
-EOL;
-
-        if (PHP_VERSION_ID < 80000) {
-            $expected = <<<'EOL'
-<token_default><?php</token_default>
-<token_keyword>echo </token_keyword><token_default>Package</token_default><token_keyword>\</token_keyword><token_default>functionName</token_default><token_keyword>();</token_keyword>
-EOL;
-        } else {
-            $expected = <<<'EOL'
-<token_default><?php</token_default>
-<token_keyword>echo </token_keyword><token_default>Package\functionName</token_default><token_keyword>();</token_keyword>
-EOL;
-        }
-
-        $this->compare($original, $expected);
     }
 }

--- a/tests/TokenizeTest.php
+++ b/tests/TokenizeTest.php
@@ -630,37 +630,53 @@ EOL;
         return $data;
     }
 
-    public function testBasicFunction()
+    /**
+     * Test the tokenizer and token specific highlighting of keyword and operator tokens.
+     *
+     * @dataProvider dataKeywordsAndOperators
+     *
+     * @param string $original The input string.
+     * @param string $expected The expected output string.
+     */
+    public function testKeywordsAndOperators($original, $expected)
     {
-        $this->compare(
-            <<<'EOL'
+        $this->compare($original, $expected);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array
+     */
+    public function dataKeywordsAndOperators()
+    {
+        return array(
+            'Keywords: instanceof' => array(
+                'original' => <<<'EOL'
+<?php
+$a instanceof stdClass;
+EOL
+                ,
+                'expected' => <<<'EOL'
+<token_default><?php</token_default>
+<token_default>$a </token_default><token_keyword>instanceof </token_keyword><token_default>stdClass</token_default><token_keyword>;</token_keyword>
+EOL
+            ),
+            'Keywords: function, return' => array(
+                'original' => <<<'EOL'
 <?php
 function plus($a, $b) {
     return $a + $b;
 }
 EOL
-            ,
-            <<<'EOL'
+                ,
+                'expected' => <<<'EOL'
 <token_default><?php</token_default>
 <token_keyword>function </token_keyword><token_default>plus</token_default><token_keyword>(</token_keyword><token_default>$a</token_default><token_keyword>, </token_keyword><token_default>$b</token_default><token_keyword>) {</token_keyword>
 <token_keyword>    return </token_keyword><token_default>$a </token_default><token_keyword>+ </token_keyword><token_default>$b</token_default><token_keyword>;</token_keyword>
 <token_keyword>}</token_keyword>
 EOL
-        );
-    }
-
-    public function testInstanceof()
-    {
-        $this->compare(
-            <<<'EOL'
-<?php
-$a instanceof stdClass;
-EOL
-            ,
-            <<<'EOL'
-<token_default><?php</token_default>
-<token_default>$a </token_default><token_keyword>instanceof </token_keyword><token_default>stdClass</token_default><token_keyword>;</token_keyword>
-EOL
+            ),
         );
     }
 }


### PR DESCRIPTION
This is a first PR in a series to improve the tests and test coverage for this package.

The PR will probably be easiest to review by looking at the commits individually.

Notes:
* All previously existing test cases, still exist.
* The additional new tests _document_ the existing functionality. No changes were made to the functionality of the package.


### Composer: improve PHPUnit version constraints

... as PHPUnit < 5.7.21 doesn't contain the forward compatibility layer with namespaced classes.

### PHPUnit: improve configuration

* Add more detailed basic test configuration
* Unless `junit` is used somewhere, generating this report for code coverage is unnecessary.
* Generating the text report, however, is useful.

### Tests: rename the test class/file to TokenizeTest

Realistically, all tests in the `HighligherTest` file are testing the handling of various token types and only incidentally testing the rest of the logic of the `Highlighter` class.

With that in mind, I'm proposing to rename the test file to make it more obvious what is being tested. This will then also allow for adding additional new test classes to test the rest of the functionality of the `Highlighter` class.

Includes adding minimal documentation and a minor method order tweak.

### TokenizeTest: use nowdocs instead of heredocs

For most tests, the text within the heredoc should _not_ be interpreted (interpolated). For those tests, it makes more sense to use nowdocs instead of heredocs.

Similar to single quoted versus double quoted strings, text within nowdocs is not interpolated (variables are not expanded), while within heredocs, they are.

Nowdocs are available since PHP 5.3, so can be safely used within this test suite.

Refs:
* https://www.php.net/manual/en/language.types.string.php#language.types.string.syntax.heredoc
* https://www.php.net/manual/en/language.types.string.php#language.types.string.syntax.nowdoc

### TokenizeTest: move "empty" tests to new test setup with data providers

This sets up a new structure for this test class using test methods with data providers.
All other existing tests will be converted to data sets in data providers in follow on commits.

### TokenizeTest: add tests for PHP tags

Note that the new test data uses NOWDOC format instead of HEREDOC format.

### TokenizeTest: move magic constant test cases to data provider

Note: this removes the looping from the test (which was a bad thing).

Advantages of using data providers compared to using a loop within the test function, are:
1. When one of the "test cases" fails, the rest of the tests cases will still be run (not so when using a loop).
    This prevents one test failure "hiding" behind another failure.
2. When there are multiple assertions is a test, it is often hard to determine which of the assertions (test cases) failed.
    Using a data provider - especially with named cases like used in this commit - will make the error coming from PHPUnit more descriptive and will make debugging which test case failed easier.
3. The test cases will now show (and be counted) as individual tests in progress reports and in testdox output.

Ref: https://phpunit.readthedocs.io/en/stable/writing-tests-for-phpunit.html#data-providers

### TokenizeTest: move miscellaneous token test cases to data provider

### TokenizeTest: add dedicated test for a T_STRING type token

### TokenizeTest: move comment token test cases to data provider

### TokenizeTest: add test cases for multi-line comments

### TokenizeTest: move text string test cases to data provider

### TokenizeTest: add additional test cases for text string handling

This adds extra tests for:
* Double quoted strings with interpolated variables.
* Nowdoc
* Heredocs with and without interpolated variables.

Note: for the nowdoc and heredoc tests, the test input is put in single quotes to prevent "nested here/nowdoc", which could skew the tests.
These test cases also need to have a new line after the `;` as otherwise PHP does not tokenize these correctly (and the highlighter is not concerned with fixing incorrect tokenization by PHP itself).

### TokenizeTest: add test for inline HTML

### TokenizeTest: move function call test cases to data provider

### TokenizeTest: move keyword test case to data provider

### TokenizeTest: add additional tests for keywords and operators

---

### 🆕 GH Actions: set `short_open_tag` ini setting for PHP 5.3 test run

The tests for this PR were failing after support for PHP 5.3 had been added back.

Reason being that the short PHP open echo tags `<?=` are only recognized as such with the ini setting `short_open_tag` turned on in PHP 5.3.

I would normally add this to the matrix to do a complete test run with and without `short_open_tag`, but as this only affects PHP 5.3, I think that's a little over the top.

Instead this commit adds a tweak to the test workflow to turn that ini setting on for the PHP 5.3 test run.

Ref: https://www.php.net/manual/en/ini.core.php#ini.short-open-tag