### PR TITLE
Tests: introduce base HighlighterTestCase, dedicated tests for the getCodeSnippet() + two bug fixes

### DIFF
--- a/src/Highlighter.php
+++ b/src/Highlighter.php
@@ -315,6 +315,6 @@ class Highlighter
             $snippet .= $line . PHP_EOL;
         }
 
-        return $snippet;
+        return rtrim($snippet, PHP_EOL);
     }
 }

--- a/src/Highlighter.php
+++ b/src/Highlighter.php
@@ -103,7 +103,13 @@ class Highlighter
 
         $offset = $lineNumber - $linesBefore - 1;
         $offset = max($offset, 0);
-        $length = $linesAfter + $linesBefore + 1;
+
+        if ($lineNumber <= $linesBefore) {
+            $length = $lineNumber + $linesAfter;
+        } else {
+            $length = $linesAfter + $linesBefore + 1;
+        }
+
         $tokenLines = array_slice($tokenLines, $offset, $length, $preserveKeys = true);
 
         $lines = $this->colorLines($tokenLines);

--- a/tests/GetCodeSnippetTest.php
+++ b/tests/GetCodeSnippetTest.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace PHP_Parallel_Lint\PhpConsoleHighlighter\Test;
+
+use PHP_Parallel_Lint\PhpConsoleHighlighter\Highlighter;
+
+/**
+ * @covers PHP_Parallel_Lint\PhpConsoleHighlighter\Highlighter::getCodeSnippet
+ * @covers PHP_Parallel_Lint\PhpConsoleHighlighter\Highlighter::getHighlightedLines
+ * @covers PHP_Parallel_Lint\PhpConsoleHighlighter\Highlighter::splitToLines
+ * @covers PHP_Parallel_Lint\PhpConsoleHighlighter\Highlighter::lineNumbers
+ */
+class GetCodeSnippetTest extends HighlighterTestCase
+{
+    /** @var string */
+    private $input = <<<'EOL'
+<?php
+
+namespace FooBar;
+
+class Foo {
+    /**
+     * @param type $param Description.
+     */
+    public function bar($param) {
+        // Do something.
+    }
+}
+?>
+EOL;
+
+    /**
+     * Test retrieving a code snippet from a larger context.
+     *
+     * @dataProvider dataGetCodeSnippet
+     *
+     * @param string $expected         Expected function output.
+     * @param int    $lineNo           Line number to get the code snippet for.
+     * @param int    $linesBeforeAfter Number of lines of code context to retrieve.
+     */
+    public function testGetCodeSnippet($expected, $lineNo, $linesBeforeAfter = 2)
+    {
+        $highlighter = new Highlighter($this->getConsoleColorMock());
+        $output      = $highlighter->getCodeSnippet($this->input, $lineNo, $linesBeforeAfter, $linesBeforeAfter);
+
+        // Allow unit tests to succeed on non-*nix systems.
+        $output = str_replace(array("\r\n", "\r"), "\n", $output);
+
+        $this->assertSame($expected, $output);
+    }
+
+    /**
+     * Data provider.
+     *
+     * Includes test cases to verify that the line number padding is handled correctly
+     * depending on the "widest" line number.
+     *
+     * @return array
+     */
+    public function dataGetCodeSnippet()
+    {
+        return array(
+            'Snippet at start of code - line 1' => array(
+                'expected' => <<<'EOL'
+<actual_line_mark>  > </actual_line_mark><line_number>1| </line_number><token_default><?php</token_default>
+    <line_number>2| </line_number>
+    <line_number>3| </line_number><token_keyword>namespace </token_keyword><token_default>FooBar</token_default><token_keyword>;</token_keyword>
+EOL
+                ,
+                'lineNo'   => 1,
+            ),
+            'Snippet at start of code - line 2' => array(
+                'expected' => <<<'EOL'
+    <line_number>1| </line_number><token_default><?php</token_default>
+<actual_line_mark>  > </actual_line_mark><line_number>2| </line_number>
+    <line_number>3| </line_number><token_keyword>namespace </token_keyword><token_default>FooBar</token_default><token_keyword>;</token_keyword>
+    <line_number>4| </line_number>
+EOL
+                ,
+                'lineNo'   => 2,
+            ),
+            'Snippet middle of code' => array(
+                'expected' => <<<'EOL'
+    <line_number> 7| </line_number><token_comment>     * @param type $param Description.</token_comment>
+    <line_number> 8| </line_number><token_comment>     */</token_comment>
+<actual_line_mark>  > </actual_line_mark><line_number> 9| </line_number><token_comment>    </token_comment><token_keyword>public function </token_keyword><token_default>bar</token_default><token_keyword>(</token_keyword><token_default>$param</token_default><token_keyword>) {</token_keyword>
+    <line_number>10| </line_number><token_keyword>        </token_keyword><token_comment>// Do something.</token_comment>
+    <line_number>11| </line_number><token_comment>    </token_comment><token_keyword>}</token_keyword>
+EOL
+                ,
+                'lineNo'   => 9,
+            ),
+            'Snippet at end of code - line before last' => array(
+                'expected' => <<<'EOL'
+    <line_number>10| </line_number><token_keyword>        </token_keyword><token_comment>// Do something.</token_comment>
+    <line_number>11| </line_number><token_comment>    </token_comment><token_keyword>}</token_keyword>
+<actual_line_mark>  > </actual_line_mark><line_number>12| </line_number><token_keyword>}</token_keyword>
+    <line_number>13| </line_number><token_default>?></token_default>
+EOL
+                ,
+                'lineNo'   => 12,
+            ),
+            'Snippet at end of code - last line' => array(
+                'expected' => <<<'EOL'
+    <line_number>11| </line_number><token_comment>    </token_comment><token_keyword>}</token_keyword>
+    <line_number>12| </line_number><token_keyword>}</token_keyword>
+<actual_line_mark>  > </actual_line_mark><line_number>13| </line_number><token_default>?></token_default>
+EOL
+                ,
+                'lineNo'   => 13,
+            ),
+            'Snippet middle of code, 1 line context' => array(
+                'expected'         => <<<'EOL'
+    <line_number> 8| </line_number><token_comment>     */</token_comment>
+<actual_line_mark>  > </actual_line_mark><line_number> 9| </line_number><token_comment>    </token_comment><token_keyword>public function </token_keyword><token_default>bar</token_default><token_keyword>(</token_keyword><token_default>$param</token_default><token_keyword>) {</token_keyword>
+    <line_number>10| </line_number><token_keyword>        </token_keyword><token_comment>// Do something.</token_comment>
+EOL
+                ,
+                'lineNo'           => 9,
+                'linesBeforeAfter' => 1,
+            ),
+            'Snippet middle of code, 3 line context' => array(
+                'expected'         => <<<'EOL'
+    <line_number> 6| </line_number><token_keyword>    </token_keyword><token_comment>/**</token_comment>
+    <line_number> 7| </line_number><token_comment>     * @param type $param Description.</token_comment>
+    <line_number> 8| </line_number><token_comment>     */</token_comment>
+<actual_line_mark>  > </actual_line_mark><line_number> 9| </line_number><token_comment>    </token_comment><token_keyword>public function </token_keyword><token_default>bar</token_default><token_keyword>(</token_keyword><token_default>$param</token_default><token_keyword>) {</token_keyword>
+    <line_number>10| </line_number><token_keyword>        </token_keyword><token_comment>// Do something.</token_comment>
+    <line_number>11| </line_number><token_comment>    </token_comment><token_keyword>}</token_keyword>
+    <line_number>12| </line_number><token_keyword>}</token_keyword>
+EOL
+                ,
+                'lineNo'           => 9,
+                'linesBeforeAfter' => 3,
+            ),
+        );
+    }
+}

--- a/tests/HighlighterTestCase.php
+++ b/tests/HighlighterTestCase.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace PHP_Parallel_Lint\PhpConsoleHighlighter\Test;
+
+use PHPUnit\Framework\TestCase;
+
+class HighlighterTestCase extends TestCase
+{
+    /**
+     * Helper method mocking the Console Color Class.
+     *
+     * @param bool $withTheme Whether or not the mock should act as if themes
+     *                        have been registered or not.
+     *
+     * @return \PHP_Parallel_Lint\PhpConsoleColor\ConsoleColor
+     */
+    protected function getConsoleColorMock($withTheme = true)
+    {
+        $mock = method_exists($this, 'createMock')
+            ? $this->createMock('\PHP_Parallel_Lint\PhpConsoleColor\ConsoleColor')
+            : $this->getMock('\PHP_Parallel_Lint\PhpConsoleColor\ConsoleColor');
+
+        $mock->expects($this->any())
+            ->method('apply')
+            ->will($this->returnCallback(function ($style, $text) use ($withTheme) {
+                if ($withTheme) {
+                    return "<$style>$text</$style>";
+                } else {
+                    return $text;
+                }
+            }));
+
+        $mock->expects($this->any())
+            ->method('hasTheme')
+            ->will($this->returnValue($withTheme));
+
+        return $mock;
+    }
+}

--- a/tests/TokenizeTest.php
+++ b/tests/TokenizeTest.php
@@ -3,7 +3,6 @@
 namespace PHP_Parallel_Lint\PhpConsoleHighlighter\Test;
 
 use PHP_Parallel_Lint\PhpConsoleHighlighter\Highlighter;
-use PHPUnit\Framework\TestCase;
 
 /**
  * Test support for all token types.
@@ -11,7 +10,7 @@ use PHPUnit\Framework\TestCase;
  * @covers PHP_Parallel_Lint\PhpConsoleHighlighter\Highlighter::tokenize
  * @covers PHP_Parallel_Lint\PhpConsoleHighlighter\Highlighter::getTokenType
  */
-class TokenizeTest extends TestCase
+class TokenizeTest extends HighlighterTestCase
 {
     /** @var Highlighter */
     private $uut;
@@ -22,30 +21,6 @@ class TokenizeTest extends TestCase
     protected function setUpHighlighter()
     {
         $this->uut = new Highlighter($this->getConsoleColorMock());
-    }
-
-    /**
-     * Helper method mocking the Console Color Class.
-     *
-     * @return \PHP_Parallel_Lint\PhpConsoleColor\ConsoleColor
-     */
-    protected function getConsoleColorMock()
-    {
-        $mock = method_exists($this, 'createMock')
-            ? $this->createMock('\PHP_Parallel_Lint\PhpConsoleColor\ConsoleColor')
-            : $this->getMock('\PHP_Parallel_Lint\PhpConsoleColor\ConsoleColor');
-
-        $mock->expects($this->any())
-            ->method('apply')
-            ->will($this->returnCallback(function ($style, $text) {
-                return "<$style>$text</$style>";
-            }));
-
-        $mock->expects($this->any())
-            ->method('hasTheme')
-            ->will($this->returnValue(true));
-
-        return $mock;
     }
 
     /**


### PR DESCRIPTION
### Tests: introduce base HighlighterTestCase

... from which all test classes should extend and which contains the `getConsoleColorMock()` method to prevent having to duplicate it in multiple places.

The method has been adjusted to be slightly more flexible for re-use, in that the `$withTheme` parameter can be used to determine whether the ConsoleColor class should behave as if themes have been registered or not.

### Tests: add dedicated tests for the getCodeSnippet() method

These tests also test the `private` `getHighlightedLines()`,  `splitToLines()` and `lineNumbers()` methods and the data sets in the data provider have been set up to ensure those methods are tested thoroughly.

### Highlighter::getCodeSnippet(): bug fix - too many lines retrieved at start of file

When a code snippet in the middle of code is retrieved, the target snippet length calculation `$length = $linesAfter + $linesBefore + 1;` functions correctly, displaying the target line in the middle, padded by x number of lines before and after.
Given `$linesBefore` and `$linesAfter` both being set to two, this would display as:
```
before
before
target
after
after
```

Similarly, when a code snippet at the end of the code is retrieved, it will work correctly as well, the target line is displayed with x number of lines before. The number of lines _after_ is limited automatically by the length of the `$tokenLines` array.
Given `$linesBefore` and `$linesAfter` both being set to two, this would display as:
```
before
before
target
```

However, when a code snippet at the _start_ of the code is retrieved, the number of lines retrieved was incorrect. The target line would display with `($linesBefore + $linesAfter)` lines _after_ the target line.

Given `$linesBefore` and `$linesAfter` both being set to two, this currently displays as:
```
target
after
after
after
after
```

... while it should be:
```
target
after
after
```

The change in this commit fixes this bug.

### Highlighter::lineNumbers(): bug fix - remove stray blank line at end of output

The `lineNumbers()` functionality adds a new line marker at the end of each line, including the last line, meaning that any code snippets being passed through this function will have a stray blank line at the end of the output.

Fixed now.