### PR TITLE
GH Actions: update PHP versions in workflows

### DIFF
--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: 'latest'
           coverage: none
           tools: cs2pr
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,11 +29,12 @@ jobs:
           - '7.3'
           - '7.4'
           - '8.0'
-          # PHP 8.1 is tested in coverage section
+          - '8.1'
+          # PHP 8.2 is tested in coverage section
         experimental: [false]
 
         include:
-          - php: '8.2'
+          - php: '8.3'
             experimental: true
 
     name: "Test on PHP ${{ matrix.php }}"
@@ -79,7 +80,7 @@ jobs:
       matrix:
         include:
           - php: 5.3
-          - php: 8.1
+          - php: 8.2
     name: "Coverage on PHP ${{ matrix.php }}"
     steps:
       - name: Checkout code
@@ -129,7 +130,7 @@ jobs:
       # Global installing is used for compatibility with composer.lock in PHP 5.3
       - name: Install Coveralls
         if: ${{ success() }}
-        run: composer global require php-coveralls/php-coveralls:"^2.4.2" --no-interaction
+        run: composer global require php-coveralls/php-coveralls:"^2.5.3" --no-interaction
 
       - name: Upload coverage results to Coveralls
         if: ${{ success() }}


### PR DESCRIPTION
PHP 8.2 has been released today :tada: and the `setup-php` action has announced support for PHP 8.3, so adding PHP 8.3 to the matrix and no longer allowing PHP 8.2 to fail the build.

Builds against PHP 8.3 are still allowed to fail for now.

Includes minor tweak setting PHP to `latest` for tasks where the PHP version isn't that relevant.