### PR TITLE
GH Actions: update for php-coveralls 2.6.0 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,18 +126,18 @@ jobs:
       - name: Run the unit tests with code coverage
         run: composer coverage
 
-      # Uploading the results with PHP Coveralls v1 won't work from GH Actions, so switch the PHP version.
-      - name: Switch to PHP 8.1
-        if: ${{ success() && matrix.php != '8.1' }}
+      # PHP Coveralls v2 (which supports GH Actions) has a PHP 5.5 minimum, so switch the PHP version.
+      - name: Switch to PHP latest
+        if: ${{ success() && matrix.php == '5.3' }}
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.1
+          php-version: 'latest'
           coverage: none
 
-      # Global installing is used for compatibility with composer.lock in PHP 5.3
+      # Global install is used to prevent a conflict with the local composer.lock.
       - name: Install Coveralls
         if: ${{ success() }}
-        run: composer global require php-coveralls/php-coveralls:"^2.5.3" --no-interaction
+        run: composer global require php-coveralls/php-coveralls:"^2.6.0" --no-interaction
 
       - name: Upload coverage results to Coveralls
         if: ${{ success() }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -155,7 +155,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Coveralls Finished
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel-finished: true


### PR DESCRIPTION
### GH Actions: used a named branch for coverallsapp

The `coverallsapp/github-action` action runner has (finally) created a named branch for the 1.x series, so let's use that.

Ref: coverallsapp/github-action#100

### GH Actions: update for php-coveralls 2.6.0 

PHP-Coveralls 2.6.0 has just been released and includes a fix for the last known PHP 8.x issue.

This means that it should now be safe to install php-coveralls on PHP 8.x and upload from there, which means we now only need the work-around for the PHP version when on PHP < 5.5 (as Coveralls v1 does not work with GH Actions).

Ref:
* https://github.com/php-coveralls/php-coveralls/releases/tag/v2.6.0