### PR TITLE
PHPUnit: allow for PHPUnit 10 + add separate configuration

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,4 +4,5 @@
 .gitignore export-ignore
 /.github export-ignore
 phpunit.xml.dist export-ignore
+phpunit10.xml.dist export-ignore
 phpcs.xml.dist export-ignore

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,8 +73,17 @@ jobs:
       - name: Lint
         run: composer phplint -- --checkstyle | cs2pr
 
-      - name: Run unit tests
+      - name: Grab PHPUnit version
+        id: phpunit_version
+        run: echo "VERSION=$(vendor/bin/phpunit --version | grep --only-matching --max-count=1 --extended-regexp '\b[0-9]+\.[0-9]+')" >> $GITHUB_OUTPUT
+
+      - name: "Run unit tests (PHPUnit < 10)"
+        if: ${{ ! startsWith( steps.phpunit_version.outputs.VERSION, '10.' ) }}
         run: composer phpunit
+
+      - name: "Run unit tests (PHPUnit 10+)"
+        if: ${{ startsWith( steps.phpunit_version.outputs.VERSION, '10.' ) }}
+        run: composer phpunit10
 
   coverage:
     needs: test
@@ -124,8 +133,17 @@ jobs:
       - name: Lint
         run: composer phplint -- --checkstyle | cs2pr
 
-      - name: Run the unit tests with code coverage
+      - name: Grab PHPUnit version
+        id: phpunit_version
+        run: echo "VERSION=$(vendor/bin/phpunit --version | grep --only-matching --max-count=1 --extended-regexp '\b[0-9]+\.[0-9]+')" >> $GITHUB_OUTPUT
+
+      - name: "Run the unit tests with code coverage (PHPUnit < 10)"
+        if: ${{ ! startsWith( steps.phpunit_version.outputs.VERSION, '10.' ) }}
         run: composer coverage
+
+      - name: "Run the unit tests with code coverage (PHPUnit 10+)"
+        if: ${{ startsWith( steps.phpunit_version.outputs.VERSION, '10.' ) }}
+        run: composer coverage10
 
       - name: Upload coverage results to Coveralls
         if: ${{ success() }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /vendor/
 /composer.lock
 phpunit.xml
+phpunit10.xml
 .phpunit.result.cache
 .phpcs.xml
 phpcs.xml

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "php-parallel-lint/php-console-color": "^1.0.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
+        "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.1",
         "php-parallel-lint/php-parallel-lint": "^1.0",
         "php-parallel-lint/php-var-dump-check": "0.*",
         "php-parallel-lint/php-code-style": "^2.0"
@@ -55,8 +55,14 @@
         "phpunit": [
             "@php ./vendor/phpunit/phpunit/phpunit --no-coverage"
         ],
+        "phpunit10": [
+            "@php ./vendor/phpunit/phpunit/phpunit -c phpunit10.xml.dist --no-coverage"
+        ],
         "coverage": [
             "@php ./vendor/phpunit/phpunit/phpunit"
+        ],
+        "coverage10": [
+            "@php ./vendor/phpunit/phpunit/phpunit -c phpunit10.xml.dist"
         ],
         "build": [
             "@phplint",
@@ -70,8 +76,10 @@
         "vardumpcheck": "Check PHP files for forgotten variable dumps",
         "phpcs": "Check PHP code style",
         "fixcs": "Auto-fix PHP code style",
-        "phpunit": "PHP unit",
-        "coverage": "PHP unit with code coverage",
+        "phpunit": "Run the unit tests on PHPUnit 4.x - 9.x without code coverage.",
+        "phpunit10": "Run the unit tests on PHPUnit 10.x without code coverage.",
+        "coverage": "Run the unit tests on PHPUnit 4.x - 9.x with code coverage.",
+        "coverage10": "Run the unit tests on PHPUnit 10.x with code coverage.",
         "build": "Run all checks"
     }
 }

--- a/phpunit10.xml.dist
+++ b/phpunit10.xml.dist
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/10.1/phpunit.xsd"
+        backupGlobals="true"
+        beStrictAboutTestsThatDoNotTestAnything="true"
+        bootstrap="./vendor/autoload.php"
+        colors="true"
+        displayDetailsOnTestsThatTriggerErrors="true"
+        displayDetailsOnTestsThatTriggerWarnings="true"
+        displayDetailsOnTestsThatTriggerNotices="true"
+        displayDetailsOnTestsThatTriggerDeprecations="true"
+        displayDetailsOnIncompleteTests="true"
+        displayDetailsOnSkippedTests="true"
+        failOnWarning="true"
+        failOnNotice="true"
+        failOnDeprecation="true"
+        requireCoverageMetadata="true"
+    >
+
+    <testsuites>
+        <testsuite name="PHP-Console-Highlighter">
+            <directory suffix="Test.php">tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <source>
+        <include>
+            <directory suffix=".php">./src/</directory>
+        </include>
+    </source>
+
+    <coverage includeUncoveredFiles="true" ignoreDeprecatedCodeUnits="true">
+        <report>
+            <clover outputFile="build/logs/clover.xml"/>
+            <html outputDirectory="build/coverage/"/>
+            <text outputFile="php://stdout" showOnlySummary="true"/>
+        </report>
+    </coverage>
+
+    <php>
+        <ini name="memory_limit" value="256M"/>
+    </php>
+</phpunit>

--- a/tests/ColorLinesTest.php
+++ b/tests/ColorLinesTest.php
@@ -12,7 +12,7 @@ use ReflectionMethod;
 class ColorLinesTest extends HighlighterTestCase
 {
     /** @var string */
-    private $input = array(
+    private static $input = array(
         7 => array (
             0 => array (
                 0 => 'token_keyword',
@@ -70,7 +70,7 @@ class ColorLinesTest extends HighlighterTestCase
      *
      * @return array
      */
-    public function dataColorLines()
+    public static function dataColorLines()
     {
         return array(
             'No lines' => array(
@@ -78,14 +78,14 @@ class ColorLinesTest extends HighlighterTestCase
                 'expected' => array(),
             ),
             'With theme' => array(
-                'input'     => $this->input,
+                'input'     => self::$input,
                 'expected'  => array(
                     7 => '<token_keyword>function </token_keyword><token_default>bar</token_default><token_keyword>(</token_keyword><token_default>$param</token_default><token_unknown>) </token_unknown><token_keyword>{}</token_keyword>',
                 ),
                 'withTheme' => true,
             ),
             'Without theme' => array(
-                'input'     => $this->input,
+                'input'     => self::$input,
                 'expected'  => array(
                     7 => 'function bar($param) {}',
                 ),
@@ -110,7 +110,7 @@ class ColorLinesTest extends HighlighterTestCase
         $method->setAccessible(true);
 
         $highlighter = new Highlighter($color);
-        $output = $method->invoke($highlighter, $this->input);
+        $output = $method->invoke($highlighter, self::$input);
         $method->setAccessible(false);
 
         $this->assertSame($expected, $output);

--- a/tests/GetCodeSnippetTest.php
+++ b/tests/GetCodeSnippetTest.php
@@ -57,7 +57,7 @@ EOL;
      *
      * @return array
      */
-    public function dataGetCodeSnippet()
+    public static function dataGetCodeSnippet()
     {
         return array(
             'Snippet at start of code - line 1' => array(

--- a/tests/GetWholeFileTest.php
+++ b/tests/GetWholeFileTest.php
@@ -14,7 +14,7 @@ class GetWholeFileTest extends HighlighterTestCase
     private $highlighter;
 
     /** @var string */
-    private $input = <<<'EOL'
+    private static $input = <<<'EOL'
 <?php
 
 namespace FooBar;
@@ -68,7 +68,7 @@ EOL;
      *
      * @return array
      */
-    public function dataGetWholeFile()
+    public static function dataGetWholeFile()
     {
         return array(
             'Empty source' => array(
@@ -85,7 +85,7 @@ EOL
 EOL
             ),
             'Multi-line' => array(
-                'input'    => $this->input,
+                'input'    => self::$input,
                 'expected' => <<<'EOL'
 <token_default><?php</token_default>
 
@@ -135,7 +135,7 @@ EOL
 <line_number>15| </line_number><token_default>?></token_default>
 EOL;
 
-        $output = $this->highlighter->getWholeFileWithLineNumbers($this->input);
+        $output = $this->highlighter->getWholeFileWithLineNumbers(self::$input);
         // Allow unit tests to succeed on non-*nix systems.
         $output = str_replace(array("\r\n", "\r"), "\n", $output);
 

--- a/tests/TokenizeTest.php
+++ b/tests/TokenizeTest.php
@@ -61,7 +61,7 @@ class TokenizeTest extends HighlighterTestCase
      *
      * @return array
      */
-    public function dataEmptyFiles()
+    public static function dataEmptyFiles()
     {
         return array(
             'Empty file' => array(
@@ -93,7 +93,7 @@ class TokenizeTest extends HighlighterTestCase
      *
      * @return array
      */
-    public function dataPhpTags()
+    public static function dataPhpTags()
     {
         return array(
             '"Long" open tag with close tag' => array(
@@ -135,7 +135,7 @@ EOL
      *
      * @return array
      */
-    public function dataMagicConstants()
+    public static function dataMagicConstants()
     {
         $magicConstants = array(
             '__FILE__',
@@ -184,7 +184,7 @@ EOL
      *
      * @return array
      */
-    public function dataMiscTokens()
+    public static function dataMiscTokens()
     {
         return array(
             'Constant (T_STRING)' => array(
@@ -263,7 +263,7 @@ EOL
      *
      * @return array
      */
-    public function dataComments()
+    public static function dataComments()
     {
         return array(
             'Doc block: single line' => array(
@@ -378,7 +378,7 @@ EOL
      *
      * @return array
      */
-    public function dataTextStrings()
+    public static function dataTextStrings()
     {
         return array(
             'Single quoted text string' => array(
@@ -499,7 +499,7 @@ EOL
      *
      * @return array
      */
-    public function dataInlineHtml()
+    public static function dataInlineHtml()
     {
         return array(
             'Inline HTML' => array(
@@ -532,7 +532,7 @@ EOL
      *
      * @return array
      */
-    public function dataNameTokens()
+    public static function dataNameTokens()
     {
         $data = array(
             'Unqualified function call' => array(
@@ -623,7 +623,7 @@ EOL;
      *
      * @return array
      */
-    public function dataKeywordsAndOperators()
+    public static function dataKeywordsAndOperators()
     {
         return array(
             'Keywords: instanceof' => array(


### PR DESCRIPTION
### Tests: make dataproviders static

As of PHPUnit 10, data providers are (again) expected to be `static` methods.

This updates the test suite to respect that.

Includes removing the use of `$this` from select data providers.

Refs:
* sebastianbergmann/phpunit@9caafe2
* sebastianbergmann/phpunit#5100

### PHPUnit: allow for PHPUnit 10 + add separate configuration

The PHPunit configuration file specification has undergone changes in PHPUnit 9.3, 10.0 and 10.1.

Most notably:
* In PHPUnit 9.3, the manner of specifying the code coverage configuration has changed.
* In PHPUnit 10.0, a significant number of attributes of the `<phpunit>` element were removed or renamed.
* In PHPUnit 10.1, there is another change related to the code coverage configuration + the ability to fail builds on deprecations/warnings/notices is brought back.

While the `--migrate-configuration` command can upgrade a configuration for the changes in the format made in PHPUnit 9.3, some of the changes in the configuration format in PHPUnit 10 don't have one-on-one replacements and/or are not taken into account.

As this package is used in the CI pipeline for other packages, it is important for this package to be ready for new PHP releases _early_, so failing the test suite on deprecations/notices and warnings is appropriate.

With that in mind, I deem it more appropriate to have a dedicated PHPUnit configuration file for PHPUnit 10 to ensure the test run will behave as intended.

This commit adds this dedicated configuration file for PHPUnit 10.1+.

Includes:
* Ignoring the new file for package archives.
* Allowing for a local override file.
* Adding scripts to the `composer.json` file to run the tests using this new configuration file and make the use of the separate config make more obvious for contributors.
* Updating the GH Actions `test` workflow to trigger the tests on PHPUnit 10 with this configuration file.

Ref:
* https://github.com/sebastianbergmann/phpunit/blob/main/ChangeLog-10.0.md#1000---2023-02-03
* sebastianbergmann/phpunit#5196
* sebastianbergmann/phpunit@fb6673f