### PR TITLE
GH Actions: PHP 8.4 has been released

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,11 +31,12 @@ jobs:
           - '8.0'
           - '8.1'
           - '8.2'
-          # PHP 8.3 is tested in coverage section
+          - '8.3'
+          # PHP 8.4 is tested in coverage section
         experimental: [false]
 
         include:
-          - php: '8.4'
+          - php: '8.5'
             experimental: true
 
     name: "Test on PHP ${{ matrix.php }}"
@@ -94,7 +95,7 @@ jobs:
       matrix:
         include:
           - php: 5.3
-          - php: 8.3
+          - php: 8.4
     name: "Coverage on PHP ${{ matrix.php }}"
     steps:
       - name: Checkout code


### PR DESCRIPTION
* Builds against PHP 8.4 are no longer allowed to fail.
* Add _allowed to fail_ build against PHP 8.5.

Ref: https://www.php.net/releases/8.4/en.php