### PR TITLE
README: have badges at top of doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 PHP Console Highlighter
 =======================
 
+[![Downloads this Month](https://img.shields.io/packagist/dm/php-parallel-lint/php-console-highlighter.svg)](https://packagist.org/packages/php-parallel-lint/php-console-highlighter)
+[![CS](https://github.com/php-parallel-lint/PHP-Console-Highlighter/actions/workflows/cs.yml/badge.svg)](https://github.com/php-parallel-lint/PHP-Console-Highlighter/actions/workflows/cs.yml)
+[![Test](https://github.com/php-parallel-lint/PHP-Console-Highlighter/actions/workflows/test.yml/badge.svg)](https://github.com/php-parallel-lint/PHP-Console-Highlighter/actions/workflows/test.yml)
+[![License](https://poser.pugx.org/php-parallel-lint/php-console-highlighter/license.svg)](https://packagist.org/packages/php-parallel-lint/php-console-highlighter)
+[![Coverage Status](https://coveralls.io/repos/github/php-parallel-lint/PHP-Console-Highlighter/badge.svg?branch=master)](https://coveralls.io/github/php-parallel-lint/PHP-Console-Highlighter?branch=master)
+
 Highlight PHP code in console (terminal).
 
 Example
@@ -28,11 +34,3 @@ $highlighter = new Highlighter(new ConsoleColor());
 $fileContent = file_get_contents(__FILE__);
 echo $highlighter->getWholeFile($fileContent);
 ```
-
-------
-
-[![Downloads this Month](https://img.shields.io/packagist/dm/php-parallel-lint/php-console-highlighter.svg)](https://packagist.org/packages/php-parallel-lint/php-console-highlighter)
-[![CS](https://github.com/php-parallel-lint/PHP-Console-Highlighter/actions/workflows/cs.yml/badge.svg)](https://github.com/php-parallel-lint/PHP-Console-Highlighter/actions/workflows/cs.yml)
-[![Test](https://github.com/php-parallel-lint/PHP-Console-Highlighter/actions/workflows/test.yml/badge.svg)](https://github.com/php-parallel-lint/PHP-Console-Highlighter/actions/workflows/test.yml)
-[![License](https://poser.pugx.org/php-parallel-lint/php-console-highlighter/license.svg)](https://packagist.org/packages/php-parallel-lint/php-console-highlighter)
-[![Coverage Status](https://coveralls.io/repos/github/php-parallel-lint/PHP-Console-Highlighter/badge.svg?branch=master)](https://coveralls.io/github/php-parallel-lint/PHP-Console-Highlighter?branch=master)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ PHP Console Highlighter
 [![Downloads this Month](https://img.shields.io/packagist/dm/php-parallel-lint/php-console-highlighter.svg)](https://packagist.org/packages/php-parallel-lint/php-console-highlighter)
 [![CS](https://github.com/php-parallel-lint/PHP-Console-Highlighter/actions/workflows/cs.yml/badge.svg)](https://github.com/php-parallel-lint/PHP-Console-Highlighter/actions/workflows/cs.yml)
 [![Test](https://github.com/php-parallel-lint/PHP-Console-Highlighter/actions/workflows/test.yml/badge.svg)](https://github.com/php-parallel-lint/PHP-Console-Highlighter/actions/workflows/test.yml)
-[![License](https://poser.pugx.org/php-parallel-lint/php-console-highlighter/license.svg)](https://packagist.org/packages/php-parallel-lint/php-console-highlighter)
+[![License](https://img.shields.io/github/license/php-parallel-lint/PHP-Console-Highlighter)](https://packagist.org/packages/php-parallel-lint/php-console-highlighter)
 [![Coverage Status](https://coveralls.io/repos/github/php-parallel-lint/PHP-Console-Highlighter/badge.svg?branch=master)](https://coveralls.io/github/php-parallel-lint/PHP-Console-Highlighter?branch=master)
 
 Highlight PHP code in console (terminal).


### PR DESCRIPTION
... as they give a quick overview of the status of the project, so having them at the top makes more sense than having them at the bottom of the README.

Includes fixing a badge which often showed as broken.