### PR TITLE
GH Actions: update for the release of PHP 8.5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,11 +32,12 @@ jobs:
           - '8.1'
           - '8.2'
           - '8.3'
-          # PHP 8.4 is tested in coverage section
+          - '8.4'
+          # PHP 8.5 is tested in coverage section
         experimental: [false]
 
         include:
-          - php: '8.5'
+          - php: '8.6'
             experimental: true
 
     name: "Test on PHP ${{ matrix.php }}"
@@ -95,7 +96,7 @@ jobs:
       matrix:
         include:
           - php: 5.3
-          - php: 8.4
+          - php: 8.5
     name: "Coverage on PHP ${{ matrix.php }}"
     steps:
       - name: Checkout code


### PR DESCRIPTION
... which is expected to be released this Thursday.

* Builds against PHP 8.5 are no longer allowed to fail.
* Update PHP version on which code coverage is run (high should now be 8.5).
* Add _allowed to fail_ build against PHP 8.6.